### PR TITLE
[WAYANG-40] Update version of spark depending on the profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ notification:
     on_success: never
     on_failure: never
     on_start: false
-#cache:
-#  directories:
-#    - .autoconf
-#    - $HOME/.m2
+cache:
+  directories:
+    - .autoconf
+    - $HOME/.m2
 
 before_install:
   - echo "${GENERATE_DOCS}"
@@ -86,7 +86,8 @@ before_script:
 #  - chmod +x ./docs/script/cibuild
 script:
   #- jdk_switcher use openjdk8
-  - bin/change-scala-version.sh 2.12.12 && mvn clean install -Pdistro,scala-12 "${mvn_opts[@]}" &> result.log
+  - bin/change-scala-version.sh 2.11.12 && mvn clean install -Pdistro,scala-11 "${mvn_opts[@]}" &> result.log
+  - bin/change-scala-version.sh 2.12.12 && mvn clean install -Pdistro,scala-12 "${mvn_opts[@]}" &>> result.log
   - cat /home/travis/build/apache/incubator-wayang/target/rat.txt || echo "file doesn't exist"
   - tail -n 2000 result.log
 

--- a/pom.xml
+++ b/pom.xml
@@ -1092,7 +1092,7 @@
                 <configuration>
                     <licenseMerges>
                         <licenseMerge>ASF 2.0 | The Apache Software License, Version 2.0 | Apache License, Version 2.0 | Apache 2.0 License | Apache License Version 2.0 | Apache 2.0 | Apache-2.0 | The Apache License, Version 2.0 | Apache License Version 2 | Apache 2 | http://www.apache.org/licenses/LICENSE-2.0.txt | Apache License 2.0 | Apache Software License - Version 2.0</licenseMerge>
-                        <licenseMerge>BSD 3-claus | 3-Clause BSD License | BSD 3 Clause License | BSD 3 Clause | BSD 3-Clause "New" or "Revised" License (BSD-3-Clause) | BSD licence | BSD | New BSD License | Revised BSD | The BSD 3-Clause License | The BSD License | The New BSD License | New BSD license | BSD 3-clause</licenseMerge>
+                        <licenseMerge>BSD 3-claus | 3-Clause BSD License | BSD 3 Clause License | BSD 3 Clause | BSD 3-Clause "New" or "Revised" License (BSD-3-Clause) | BSD licence | BSD | New BSD License | Revised BSD | The BSD 3-Clause License | The BSD License | The New BSD License | New BSD license | BSD 3-clause | BSD 3-Clause </licenseMerge>
                         <licenseMerge>MIT | MIT License | The MIT License </licenseMerge>
                         <licenseMerge>BSD 2-claus | BSD 2-Clause License | BSD 2-Clause</licenseMerge>
                         <licenseMerge>HSQLDB | HSQLDB License, a BSD open source license</licenseMerge>

--- a/pom.xml
+++ b/pom.xml
@@ -1103,7 +1103,7 @@
                     </includedLicenses>
                     <failOnBlacklist>true</failOnBlacklist>
                     <excludedGroups>
-                        org.apache.spark.*|org.apache.hadoop.*|org.apache.giraph.*|org.antlr.*|junit.*
+                        org.apache.spark.*|org.apache.hadoop.*|org.apache.giraph.*|org.antlr.*|junit.*|org.graphchi.*
                     </excludedGroups>
                     <excludeTransitiveDependencies>true</excludeTransitiveDependencies>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,6 @@
         <hadoop.version>2.7.7</hadoop.version>
         <!-- To be overridden by individual modules -->
         <java-module-name>org.apache.wayang.default</java-module-name>
-        <scala.version>2.11.12</scala.version>
-        <scala.mayor.version>2.11</scala.mayor.version>
         <code.coverage.project.folder>${basedir}/</code.coverage.project.folder>
         <code.coverage.overall.data.folder>${basedir}/target/aggregate.exec</code.coverage.overall.data.folder>
     </properties>
@@ -579,6 +577,7 @@
             <properties>
                 <scala.version>2.11.12</scala.version>
                 <scala.mayor.version>2.11</scala.mayor.version>
+                <spark.version>2.4.8</spark.version>
             </properties>
         </profile>
 
@@ -587,6 +586,7 @@
             <properties>
                 <scala.version>2.12.12</scala.version>
                 <scala.mayor.version>2.12</scala.mayor.version>
+                <spark.version>3.1.2</spark.version>
             </properties>
         </profile>
 
@@ -595,6 +595,7 @@
             <properties>
                 <scala.version>2.13.3</scala.version>
                 <scala.mayor.version>2.13</scala.mayor.version>
+                <spark.version>3.1.2</spark.version>
             </properties>
         </profile>
 

--- a/wayang-api/wayang-api-python/pom.xml
+++ b/wayang-api/wayang-api-python/pom.xml
@@ -36,6 +36,5 @@
 
     <properties>
         <java-module-name>org.apache.wayang.api</java-module-name>
-        <spark.version>3.1.2</spark.version>
     </properties>
 </project>

--- a/wayang-api/wayang-api-scala-java/pom.xml
+++ b/wayang-api/wayang-api-scala-java/pom.xml
@@ -34,8 +34,6 @@
 
     <properties>
         <java-module-name>org.apache.wayang.api</java-module-name>
-        <spark.version>3.1.2</spark.version>
-        <scala.mayor.version>2.12</scala.mayor.version>
     </properties>
 
     <dependencyManagement>

--- a/wayang-platforms/wayang-spark/pom.xml
+++ b/wayang-platforms/wayang-spark/pom.xml
@@ -36,8 +36,6 @@
 
     <properties>
         <java-module-name>org.apache.wayang.platform.spark</java-module-name>
-        <spark.version>3.1.2</spark.version>
-        <scala.mayor.version>2.12</scala.mayor.version>
     </properties>
 
 

--- a/wayang-platforms/wayang-spark/pom.xml
+++ b/wayang-platforms/wayang-spark/pom.xml
@@ -89,13 +89,11 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>2.7.7</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>2.7.7</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/wayang-platforms/wayang-spark/pom.xml
+++ b/wayang-platforms/wayang-spark/pom.xml
@@ -83,7 +83,6 @@
             <groupId>com.thoughtworks.paranamer</groupId>
             <artifactId>paranamer</artifactId>
             <version>2.8</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/wayang-plugins/wayang-iejoin/pom.xml
+++ b/wayang-plugins/wayang-iejoin/pom.xml
@@ -24,8 +24,6 @@
 
     <properties>
         <java-module-name>org.apache.wayang.extensions.iejoin</java-module-name>
-        <spark.version>3.1.2</spark.version>
-        <scala.mayor.version>2.12</scala.mayor.version>
     </properties>
 
     <dependencies>

--- a/wayang-profiler/pom.xml
+++ b/wayang-profiler/pom.xml
@@ -34,8 +34,6 @@
 
     <properties>
         <java-module-name>org.apache.wayang.profiler</java-module-name>
-        <spark.version>3.1.2</spark.version>
-        <scala.mayor.version>2.12</scala.mayor.version>
     </properties>
 
     <dependencyManagement>
@@ -99,7 +97,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.graphchi</groupId>
-                    <artifactId>graphchi-java_${scala.mayor.version}</artifactId>
+                    <artifactId>graphchi-java_2.11</artifactId>
                     <version>0.2.2</version>
                     <scope>test</scope>
                     <exclusions>

--- a/wayang-tests-integration/pom.xml
+++ b/wayang-tests-integration/pom.xml
@@ -35,8 +35,6 @@
     <properties>
         <java-module-name>org.apache.wayang.test.integration</java-module-name>
         <graphchi.version>0.2.2</graphchi.version>
-        <spark.version>3.1.2</spark.version>
-        <scala.mayor.version>2.12</scala.mayor.version>
         <flink.version>1.7.1</flink.version>
         <giraph.version>1.2.0-hadoop2</giraph.version>
     </properties>
@@ -280,8 +278,8 @@
                 </dependency>
                 <dependency>
                     <groupId>org.graphchi</groupId>
-                    <artifactId>graphchi-java_${scala.mayor.version}</artifactId>
-                    <version>${graphchi.version}</version>
+                    <artifactId>graphchi-java_2.11</artifactId>
+                    <version>0.2.2</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>


### PR DESCRIPTION
During the compilation in the profile scala-11, it was not compiling the code because the version of Apache Spark was not compatible. It created a change of version depending on the profile. In the case of profile scala-11 the Apache Spark will be 2.4.8. However,  in other profiles like scala-12 the Apache Spark version will 3.X