### PR TITLE
Change SelectNearestCentroidFunction to use org.apache.logging.log4j.LogManager instead of org.slf4j.LoggerFactory

### DIFF
--- a/wayang-benchmark/src/main/scala/org/apache/wayang/apps/simwords/SelectNearestCentroidFunction.scala
+++ b/wayang-benchmark/src/main/scala/org/apache/wayang/apps/simwords/SelectNearestCentroidFunction.scala
@@ -21,7 +21,7 @@ package org.apache.wayang.apps.simwords
 import org.apache.wayang.core.function.ExecutionContext
 import org.apache.wayang.core.function.FunctionDescriptor.ExtendedSerializableFunction
 import org.apache.wayang.core.util.WayangCollections
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.JavaConversions._
 import scala.util.Random
@@ -33,7 +33,7 @@ import scala.util.Random
 class SelectNearestCentroidFunction(broadcastName: String)
   extends ExtendedSerializableFunction[(Int, SparseVector), (Int, SparseVector, Int)] {
 
-  private lazy val logger = LoggerFactory.getLogger(getClass)
+  private lazy val logger = LogManager.getLogger(getClass)
 
   private var centroids: java.util.List[(Int, SparseVector)] = _
 


### PR DESCRIPTION
As discussed on the mailing list, this resolves an issue where IntelliJ cannot build the project due to a faulty maven import. I'm thinking that it might be something like the following IntelliJ bug, because we are importing Spark in a tricky way (different versions based on different profiles):
https://youtrack.jetbrains.com/issue/IDEA-98503

This was the only place in the code where `org.slf4j.LoggerFactory` was used.