### PR TITLE
removed wrong placed license

### DIFF
--- a/wayang-commons/wayang-utils-profile-db/src/main/java/org/apache/wayang/commons/util/profiledb/instrumentation/StopWatch.java
+++ b/wayang-commons/wayang-utils-profile-db/src/main/java/org/apache/wayang/commons/util/profiledb/instrumentation/StopWatch.java
@@ -1,19 +1,6 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ Copyright 2016 Sebastian Kruse, Licensed under the Apache License, Version 2.0
+https://github.com/sekruse/profiledb-java.git
  */
 
 package org.apache.wayang.commons.util.profiledb.instrumentation;


### PR DESCRIPTION
Code, which does not come from an direct apache wayang comitter can't be re-licensed, instead the inclusion has to be noted in NOTICE. A good practise is to add the short notice into the files why the standard header is missing.