### PR TITLE
[BUG] delete paranamer-2.3 from dependecies

### DIFF
--- a/wayang-commons/pom.xml
+++ b/wayang-commons/pom.xml
@@ -77,6 +77,10 @@
                         <groupId>tomcat</groupId>
                         <artifactId>jasper-runtime</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.thoughtworks.paranamer</groupId>
+                        <artifactId>paranamer</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -156,6 +160,10 @@
                     <exclusion>
                         <groupId>commons-el</groupId>
                         <artifactId>commons-el</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.thoughtworks.paranamer</groupId>
+                        <artifactId>paranamer</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/wayang-tests-integration/pom.xml
+++ b/wayang-tests-integration/pom.xml
@@ -93,12 +93,24 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.paranamer</groupId>
+                    <artifactId>paranamer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.paranamer</groupId>
+                    <artifactId>paranamer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
delete paranamer-2.3 from dependecies to just work with paranamer 2.8, because exception at runtime in spark and other platforms