### PR TITLE
Update several dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1270,9 +1270,8 @@
                         <licenseMerge>ASF 2.0 | The Apache Software License, Version 2.0 | Apache License, Version 2.0 | Apache 2.0 License | Apache License Version 2.0 | Apache 2.0 | Apache-2.0 | The Apache License, Version 2.0 | Apache License Version 2 | Apache 2 | http://www.apache.org/licenses/LICENSE-2.0.txt | Apache License 2.0 | Apache Software License - Version 2.0</licenseMerge>
                         <licenseMerge>BSD 3-claus | 3-Clause BSD License | BSD 3 Clause License | BSD 3 Clause | BSD 3-Clause "New" or "Revised" License (BSD-3-Clause) | BSD licence | BSD | New BSD License | Revised BSD | The BSD 3-Clause License | The BSD License | The New BSD License | New BSD license | BSD 3-clause | BSD 3-Clause </licenseMerge>
                         <licenseMerge>MIT | MIT License | The MIT License </licenseMerge>
-                        <licenseMerge>BSD 2-claus | BSD 2-Clause License | BSD 2-Clause</licenseMerge>
+                        <licenseMerge>BSD 2-claus | BSD 2-Clause License | BSD 2-Clause | BSD-2-Clause</licenseMerge>
                         <licenseMerge>HSQLDB | HSQLDB License, a BSD open source license</licenseMerge>
-                        <licenseMerge>PostgreSQL | The PostgreSQL License</licenseMerge>
                     </licenseMerges>
                     <includedLicenses>
                         ASF 2.0 | BSD 2-claus | BSD 3-claus | MIT | CC0 | HSQLDB | PostgreSQL

--- a/wayang-commons/pom.xml
+++ b/wayang-commons/pom.xml
@@ -175,7 +175,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.17</version>
+                <version>1.26</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -185,7 +185,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>de.odysseus.juel</groupId>

--- a/wayang-docs/src/main/resources/Gemfile.lock
+++ b/wayang-docs/src/main/resources/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     asciidoctor (2.0.12)
     coderay (1.1.3)
@@ -43,7 +43,7 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -58,7 +58,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.26.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
@@ -71,6 +71,7 @@ PLATFORMS
   universal-darwin-19
   universal-darwin-20
   universal-java-1.8
+  x86_64-linux
 
 DEPENDENCIES
   coderay (~> 1.1.0)

--- a/wayang-platforms/wayang-postgres/pom.xml
+++ b/wayang-platforms/wayang-postgres/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <java-module-name>org.apache.wayang.platform.postgres</java-module-name>
-        <postgres.version>9.4.1208</postgres.version>
+        <postgres.version>42.3.3</postgres.version>
     </properties>
 
     <dependencies>

--- a/wayang-platforms/wayang-spark/pom.xml
+++ b/wayang-platforms/wayang-spark/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.7</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Bump postgresql in /wayang-platforms/wayang-postgres (#4)

Bumps [postgresql](https://github.com/pgjdbc/pgjdbc) from 9.4.1208 to 42.3.3.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/compare/REL9.4.1208...REL42.3.3)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Bump snakeyaml from 1.17 to 1.26 in /wayang-commons (#5)

Bumps [snakeyaml](https://bitbucket.org/asomov/snakeyaml) from 1.17 to 1.26.
- [Commits](https://bitbucket.org/asomov/snakeyaml/commits)

---
updated-dependencies:
- dependency-name: org.yaml:snakeyaml
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Bump hadoop-common in /wayang-platforms/wayang-spark (#6)

Bumps hadoop-common from 2.7.7 to 2.10.1.

---
updated-dependencies:
- dependency-name: org.apache.hadoop:hadoop-common
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Bump addressable from 2.7.0 to 2.8.0 in /wayang-docs/src/main/resources (#2)

Bumps [addressable](https://github.com/sporkmonger/addressable) from 2.7.0 to 2.8.0.
- [Release notes](https://github.com/sporkmonger/addressable/releases)
- [Changelog](https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md)
- [Commits](https://github.com/sporkmonger/addressable/compare/addressable-2.7.0...addressable-2.8.0)

---
updated-dependencies:
- dependency-name: addressable
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Bump kramdown from 2.3.0 to 2.3.1 in /wayang-docs/src/main/resources (#1)

Bumps [kramdown](https://github.com/gettalong/kramdown) from 2.3.0 to 2.3.1.
- [Release notes](https://github.com/gettalong/kramdown/releases)
- [Changelog](https://github.com/gettalong/kramdown/blob/master/doc/news.page)
- [Commits](https://github.com/gettalong/kramdown/commits)

---
updated-dependencies:
- dependency-name: kramdown
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Bump commons-io from 2.4 to 2.7 in /wayang-commons (#7)

Bumps commons-io from 2.4 to 2.7.

---
updated-dependencies:
- dependency-name: commons-io:commons-io
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>