### PR TITLE
[WAYANG-IDE] add file to recognize the scala code in the IDE's

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/README.md
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-benchmark/src/main/scala/README.md
+++ b/wayang-benchmark/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-benchmark/src/main/scala/README.md
+++ b/wayang-benchmark/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables

--- a/wayang-platforms/wayang-flink/src/main/scala/README.md
+++ b/wayang-platforms/wayang-flink/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-platforms/wayang-flink/src/main/scala/README.md
+++ b/wayang-platforms/wayang-flink/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables

--- a/wayang-platforms/wayang-spark/src/main/scala/README.md
+++ b/wayang-platforms/wayang-spark/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-platforms/wayang-spark/src/main/scala/README.md
+++ b/wayang-platforms/wayang-spark/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables

--- a/wayang-plugins/wayang-iejoin/src/main/scala/README.md
+++ b/wayang-plugins/wayang-iejoin/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-plugins/wayang-iejoin/src/main/scala/README.md
+++ b/wayang-plugins/wayang-iejoin/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables

--- a/wayang-profiler/src/main/scala/README.md
+++ b/wayang-profiler/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-profiler/src/main/scala/README.md
+++ b/wayang-profiler/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables

--- a/wayang-tests-integration/src/main/scala/README.md
+++ b/wayang-tests-integration/src/main/scala/README.md
@@ -13,4 +13,4 @@
 [comment]: # (See the License for the specific language governing permissions and)
 [comment]: # (limitations under the License.)
 
-In this folder it was created to avoid error in the parameters of the variables
+This directory was created to avoid errors with the parameters from variables

--- a/wayang-tests-integration/src/main/scala/README.md
+++ b/wayang-tests-integration/src/main/scala/README.md
@@ -1,0 +1,16 @@
+[comment]: # (Licensed to the Apache Software Foundation (ASF) under one or more)
+[comment]: # (contributor license agreements.  See the NOTICE file distributed with)
+[comment]: # (this work for additional information regarding copyright ownership.)
+[comment]: # (The ASF licenses this file to You under the Apache License, Version 2.0)
+[comment]: # ((the "License"); you may not use this file except in compliance with)
+[comment]: # (the License.  You may obtain a copy of the License at)
+[comment]: # ()
+[comment]: # (http://www.apache.org/licenses/LICENSE-2.0)
+[comment]: # ()
+[comment]: # (Unless required by applicable law or agreed to in writing, software)
+[comment]: # (distributed under the License is distributed on an "AS IS" BASIS,)
+[comment]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
+[comment]: # (See the License for the specific language governing permissions and)
+[comment]: # (limitations under the License.)
+
+In this folder it was created to avoid error in the parameters of the variables


### PR DESCRIPTION
Several IDE load the project from the pom.xml file and activate the scala version recognization required to enable the scala profile, and the profile is automatically activated when the file `src/main/scala` [exist](https://github.com/apache/incubator-wayang/blob/1ca1e49822a8a65f6665d4616f8391ba12594234/pom.xml#L425-L431)

