### PR TITLE
Initial version of the SQL API

### DIFF
--- a/wayang-api/pom.xml
+++ b/wayang-api/pom.xml
@@ -38,6 +38,7 @@
     <modules>
         <module>wayang-api-scala-java</module>
         <module>wayang-api-python</module>
+        <module>wayang-api-sql</module>
     </modules>
 
 </project>

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -40,11 +40,11 @@
             <artifactId>calcite-linq4j</artifactId>
             <version>1.29.0</version>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-file</artifactId>
             <version>1.29.0</version>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.apache.wayang</groupId>
             <artifactId>wayang-core</artifactId>

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -66,12 +66,12 @@
             <version>0.6.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.wayang</groupId>
-            <artifactId>wayang-spark</artifactId>
-            <version>0.6.1-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.wayang</groupId>-->
+<!--            <artifactId>wayang-spark</artifactId>-->
+<!--            <version>0.6.1-SNAPSHOT</version>-->
+<!--            <scope>compile</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>wayang-api</artifactId>
+        <groupId>org.apache.wayang</groupId>
+        <version>0.6.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wayang-api-sql</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.29.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-linq4j</artifactId>
+            <version>1.29.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-file</artifactId>
+            <version>1.29.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-core</artifactId>
+            <version>0.6.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-postgres</artifactId>
+            <version>0.6.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-spark_2.12</artifactId>
+            <version>0.6.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-spark</artifactId>
+            <version>0.6.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.10.2</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/convention/WayangConvention.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/convention/WayangConvention.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.wayang.api.sql.calcite.convention;
+
+import org.apache.calcite.plan.*;
+import org.apache.wayang.api.sql.calcite.rel.WayangRel;
+
+public enum WayangConvention implements Convention {
+    INSTANCE;
+
+    @Override
+    public Class getInterface() {
+        return WayangRel.class;
+    }
+
+    @Override
+    public String getName() {
+        return toString();
+    }
+
+    @Override
+    public boolean canConvertConvention(Convention toConvention) {
+        return false;
+    }
+
+    @Override
+    public boolean useAbstractConvertersForConversion(RelTraitSet fromTraits, RelTraitSet toTraits) {
+        return false;
+    }
+
+
+    @Override
+    public RelTraitDef getTraitDef() {
+        return ConventionTraitDef.INSTANCE;
+    }
+
+    @Override
+    public boolean satisfies(RelTrait relTrait) {
+        return this == relTrait;
+    }
+
+    @Override
+    public void register(RelOptPlanner relOptPlanner) {
+
+    }
+
+
+    @Override
+    public String toString() {
+        return "WAYANG";
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.converter;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
@@ -1,0 +1,167 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.*;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.wayang.api.sql.calcite.rel.WayangFilter;
+import org.apache.wayang.api.sql.calcite.utils.PrintUtils;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.FilterOperator;
+import org.apache.wayang.core.function.FunctionDescriptor;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class WayangFilterVisitor extends WayangRelNodeVisitor<WayangFilter> {
+    WayangFilterVisitor(WayangRelConverter wayangRelConverter) {
+        super(wayangRelConverter);
+    }
+
+    @Override
+    Operator visit(WayangFilter wayangRelNode) {
+
+        Operator childOp = wayangRelConverter.convert(wayangRelNode.getInput(0));
+
+        RexNode condition = ((Filter) wayangRelNode).getCondition();
+
+        FilterOperator<Record> filter = new FilterOperator(
+                new FilterPredicateImpl(condition),
+                Record.class
+        );
+
+        childOp.connectTo(0,filter,0);
+
+        return filter;
+    }
+
+
+    private class FilterPredicateImpl implements FunctionDescriptor.SerializablePredicate<Record> {
+
+        private final RexNode condition;
+
+        private FilterPredicateImpl(RexNode condition) {
+            this.condition = condition;
+        }
+
+        @Override
+        public boolean test(Record record) {
+            return condition.accept(new EvaluateFilterCondition(true, record));
+        }
+    }
+
+
+    private class EvaluateFilterCondition extends RexVisitorImpl<Boolean> {
+
+        final Record record;
+        protected EvaluateFilterCondition(boolean deep, Record record) {
+            super(deep);
+            this.record = record;
+        }
+
+        @Override
+        public Boolean visitCall(RexCall call) {
+            SqlKind kind = call.getKind();
+            if(!kind.belongsTo(SUPPORTED_OPS)) {
+                throw new IllegalStateException("Cannot handle this filter predicate yet");
+            }
+
+            RexNode leftOperand = call.getOperands().get(0);
+            RexNode rightOperand = call.getOperands().get(1);
+
+            if(kind == SqlKind.AND) {
+                return leftOperand.accept(this) && rightOperand.accept(this);
+            } else if(kind == SqlKind.OR) {
+                return leftOperand.accept(this) || rightOperand.accept(this);
+            } else {
+                return eval(record, kind, leftOperand, rightOperand);
+            }
+        }
+
+        public boolean eval(Record record, SqlKind kind, RexNode leftOperand, RexNode rightOperand) {
+
+            if(leftOperand instanceof RexInputRef && rightOperand instanceof RexLiteral) {
+                RexInputRef rexInputRef = (RexInputRef)leftOperand;
+                int index = rexInputRef.getIndex();
+                Object field = record.getField(index);
+                RexLiteral rexLiteral = (RexLiteral) rightOperand;
+                switch (kind) {
+                    case GREATER_THAN:
+                        return isGreaterThan(field, rexLiteral);
+                    case LESS_THAN:
+                        return isLessThan(field, rexLiteral);
+                    case EQUALS:
+                        return isEqualTo(field, rexLiteral);
+                    case GREATER_THAN_OR_EQUAL:
+                        return isGreaterThan(field, rexLiteral) || isEqualTo(field, rexLiteral);
+                    case LESS_THAN_OR_EQUAL:
+                        return isLessThan(field, rexLiteral) || isEqualTo(field, rexLiteral);
+                    default:
+                        throw new IllegalStateException("Predicate not supported yet");
+
+                }
+
+            } else {
+                throw new IllegalStateException("Predicate not supported yet");
+            }
+
+        }
+
+        private boolean isGreaterThan(Object o, RexLiteral rexLiteral) {
+//            return rexLiteral.getValue().compareTo(o)< 0;
+            return ((Comparable)o).compareTo(rexLiteral.getValueAs(o.getClass())) > 0;
+
+        }
+
+        private boolean isLessThan(Object o, RexLiteral rexLiteral) {
+            return ((Comparable)o).compareTo(rexLiteral.getValueAs(o.getClass())) < 0;
+        }
+
+        private boolean isEqualTo(Object o, RexLiteral rexLiteral) {
+            try {
+                return ((Comparable)o).compareTo(rexLiteral.getValueAs(o.getClass())) == 0;
+            } catch (Exception e) {
+                throw new IllegalStateException("Predicate not supported yet");
+            }
+        }
+    }
+
+    /**for quick sanity check **/
+    private static final EnumSet<SqlKind> SUPPORTED_OPS =
+            EnumSet.of(SqlKind.AND, SqlKind.OR,
+                    SqlKind.EQUALS, SqlKind.NOT_EQUALS,
+                    SqlKind.LESS_THAN, SqlKind.GREATER_THAN,
+                    SqlKind.GREATER_THAN_OR_EQUAL, SqlKind.LESS_THAN_OR_EQUAL);
+
+
+
+
+
+
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.converter;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+
+public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
+
+    WayangJoinVisitor(WayangRelConverter wayangRelConverter) {
+        super(wayangRelConverter);
+    }
+
+    @Override
+    Operator visit(WayangJoin wayangRelNode) {
+
+
+
+        return null;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangProjectVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangProjectVisitor.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.wayang.api.sql.calcite.rel.WayangProject;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.MapOperator;
+import org.apache.wayang.core.function.FunctionDescriptor;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WayangProjectVisitor extends WayangRelNodeVisitor<WayangProject> {
+    WayangProjectVisitor(WayangRelConverter wayangRelConverter) {
+        super(wayangRelConverter);
+    }
+
+    @Override
+    Operator visit(WayangProject wayangRelNode) {
+
+        Operator childOp = wayangRelConverter.convert(wayangRelNode.getInput(0));
+
+        /* Quick check */
+        List<RexNode> projects = ((Project) wayangRelNode).getProjects();
+        for(RexNode rexNode : projects) {
+            if (!(rexNode instanceof RexInputRef)) {
+                throw new IllegalStateException("Generalized Projections not supported yet");
+            }
+        }
+
+        //TODO: create a map with specific dataset type
+        MapOperator<Record, Record> projection = new MapOperator(
+                new MapFunctionImpl(projects),
+                Record.class,
+                Record.class);
+
+        childOp.connectTo(0, projection, 0);
+
+        return projection;
+    }
+
+
+    private class MapFunctionImpl implements
+            FunctionDescriptor.SerializableFunction<Record, Record> {
+
+        private final int[] fields;
+
+        private MapFunctionImpl(int[] fields) {
+            this. fields = fields;
+        }
+
+        private MapFunctionImpl(List<RexNode> projects) {
+            this(getProjectFields(projects));
+        }
+
+        @Override
+        public Record apply(Record record) {
+
+            List<Object> projectedRecord = new ArrayList<>();
+            for(int field : fields) {
+                projectedRecord.add(record.getField(field));
+            }
+
+            return new Record(projectedRecord.toArray(new Object[0]));
+        }
+    }
+
+    private static int[] getProjectFields(List<RexNode> projects) {
+        final int[] fields = new int[projects.size()];
+        for (int i = 0; i < projects.size(); i++) {
+            final RexNode exp = projects.get(i);
+            if (exp instanceof RexInputRef) {
+                fields[i] = ((RexInputRef) exp).getIndex();
+            } else {
+                return null; // not a simple projection
+            }
+        }
+        return fields;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangProjectVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangProjectVisitor.java
@@ -1,20 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.wayang.api.sql.calcite.rel.WayangFilter;
+import org.apache.wayang.api.sql.calcite.rel.WayangProject;
+import org.apache.wayang.api.sql.calcite.rel.WayangTableScan;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+
+public class WayangRelConverter {
+
+    public Operator convert(RelNode node) {
+        if(node instanceof WayangTableScan) {
+            return new WayangTableScanVisitor(this).visit((WayangTableScan)node);
+        } else if (node instanceof WayangProject) {
+            return new WayangProjectVisitor(this).visit((WayangProject) node);
+        } else if (node instanceof WayangFilter) {
+            return new WayangFilterVisitor(this).visit((WayangFilter) node);
+        }
+        throw new IllegalStateException("Operator translation not supported yet");
+    }
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
@@ -1,20 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelNodeVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelNodeVisitor.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+
+abstract class WayangRelNodeVisitor<T extends RelNode> {
+
+    final WayangRelConverter wayangRelConverter;
+
+    WayangRelNodeVisitor(WayangRelConverter wayangRelConverter) {
+        this.wayangRelConverter = wayangRelConverter;
+    }
+
+    abstract Operator visit(T wayangRelNode);
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelNodeVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelNodeVisitor.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.converter;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.converter;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.wayang.api.sql.calcite.rel.WayangTableScan;
+import org.apache.wayang.api.sql.sources.fs.JavaCSVTableSource;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.TableSource;
+import org.apache.wayang.basic.operators.TextFileSource;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.types.DataSetType;
+import org.apache.wayang.postgres.Postgres;
+import org.apache.wayang.postgres.operators.PostgresTableSource;
+import org.apache.wayang.postgres.platform.PostgresPlatform;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WayangTableScanVisitor extends WayangRelNodeVisitor<WayangTableScan> {
+    WayangTableScanVisitor(WayangRelConverter wayangRelConverter) {
+        super(wayangRelConverter);
+    }
+
+    @Override
+    Operator visit(WayangTableScan wayangRelNode) {
+
+        String tableName = wayangRelNode.getTableName();
+        List<String> columnNames = wayangRelNode.getColumnNames();
+
+
+        //TODO: resolve table source to platform specific source
+        //TODO: create tablesource with column types
+
+
+        RelDataType rowType = wayangRelNode.getRowType();
+
+        List<RelDataType> fieldTypes = new ArrayList<>();
+
+        for(RelDataTypeField field : rowType.getFieldList()) {
+            fieldTypes.add(field.getType());
+        }
+
+        return new JavaCSVTableSource("file:/data/Projects/databloom/test-data/orders.csv",
+                DataSetType.createDefault(Record.class),
+                fieldTypes);
+
+//        return new PostgresTableSource(tableName);
+
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcSchema.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcSchema.java
@@ -1,0 +1,557 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wayang.api.sql.calcite.jdbc;
+
+import com.google.common.collect.*;
+import org.apache.calcite.adapter.jdbc.JdbcConvention;
+//import org.apache.calcite.adapter.jdbc.JdbcTable;
+//import org.apache.calcite.adapter.jdbc.JdbcUtils;
+import org.apache.calcite.avatica.AvaticaUtils;
+import org.apache.calcite.avatica.MetaImpl;
+import org.apache.calcite.avatica.SqlType;
+import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.rel.type.*;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.*;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlDialectFactory;
+import org.apache.calcite.sql.SqlDialectFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.*;
+import java.util.function.BiFunction;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation of {@link Schema} that is backed by a JDBC data source.
+ *
+ * <p>The tables in the JDBC data source appear to be tables in this schema;
+ * queries against this schema are executed against those tables, pushing down
+ * as much as possible of the query logic to SQL.</p>
+ */
+public class JdbcSchema implements Schema {
+  final DataSource dataSource;
+  final @Nullable String catalog;
+  final @Nullable String schema;
+  public final SqlDialect dialect;
+  final JdbcConvention convention;
+  private @Nullable ImmutableMap<String, JdbcTable> tableMap;
+  private final boolean snapshot;
+
+  @Experimental
+  public static final ThreadLocal<@Nullable Foo> THREAD_METADATA = new ThreadLocal<>();
+
+  private static final Ordering<Iterable<Integer>> VERSION_ORDERING =
+      Ordering.<Integer>natural().lexicographical();
+
+  /**
+   * Creates a JDBC schema.
+   *
+   * @param dataSource Data source
+   * @param dialect SQL dialect
+   * @param convention Calling convention
+   * @param catalog Catalog name, or null
+   * @param schema Schema name pattern
+   */
+  public JdbcSchema(DataSource dataSource, SqlDialect dialect,
+                    JdbcConvention convention, @Nullable String catalog, @Nullable String schema) {
+    this(dataSource, dialect, convention, catalog, schema, null);
+  }
+
+  private JdbcSchema(DataSource dataSource, SqlDialect dialect,
+                     JdbcConvention convention, @Nullable String catalog, @Nullable String schema,
+                     @Nullable ImmutableMap<String, JdbcTable> tableMap) {
+    this.dataSource = requireNonNull(dataSource, "dataSource");
+    this.dialect = requireNonNull(dialect, "dialect");
+    this.convention = convention;
+    this.catalog = catalog;
+    this.schema = schema;
+    this.tableMap = tableMap;
+    this.snapshot = tableMap != null;
+  }
+
+  public static JdbcSchema create(
+      SchemaPlus parentSchema,
+      String name,
+      DataSource dataSource,
+      @Nullable String catalog,
+      @Nullable String schema) {
+    return create(parentSchema, name, dataSource,
+        SqlDialectFactoryImpl.INSTANCE, catalog, schema);
+  }
+
+  public static JdbcSchema create(
+      SchemaPlus parentSchema,
+      String name,
+      DataSource dataSource,
+      SqlDialectFactory dialectFactory,
+      @Nullable String catalog,
+      @Nullable String schema) {
+    final Expression expression =
+        Schemas.subSchemaExpression(parentSchema, name, JdbcSchema.class);
+    final SqlDialect dialect = createDialect(dialectFactory, dataSource);
+    final JdbcConvention convention =
+        JdbcConvention.of(dialect, expression, name);
+    return new JdbcSchema(dataSource, dialect, convention, catalog, schema);
+  }
+
+  /**
+   * Creates a JdbcSchema, taking credentials from a map.
+   *
+   * @param parentSchema Parent schema
+   * @param name Name
+   * @param operand Map of property/value pairs
+   * @return A JdbcSchema
+   */
+  public static JdbcSchema create(
+      SchemaPlus parentSchema,
+      String name,
+      Map<String, Object> operand) {
+    DataSource dataSource;
+    try {
+      final String dataSourceName = (String) operand.get("dataSource");
+      if (dataSourceName != null) {
+        dataSource =
+            AvaticaUtils.instantiatePlugin(DataSource.class, dataSourceName);
+      } else {
+        final String jdbcUrl = (String) requireNonNull(operand.get("jdbcUrl"), "jdbcUrl");
+        final String jdbcDriver = (String) operand.get("jdbcDriver");
+        final String jdbcUser = (String) operand.get("jdbcUser");
+        final String jdbcPassword = (String) operand.get("jdbcPassword");
+        dataSource = dataSource(jdbcUrl, jdbcDriver, jdbcUser, jdbcPassword);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error while reading dataSource", e);
+    }
+    String jdbcCatalog = (String) operand.get("jdbcCatalog");
+    String jdbcSchema = (String) operand.get("jdbcSchema");
+    String sqlDialectFactory = (String) operand.get("sqlDialectFactory");
+
+    if (sqlDialectFactory == null || sqlDialectFactory.isEmpty()) {
+      return JdbcSchema.create(
+          parentSchema, name, dataSource, jdbcCatalog, jdbcSchema);
+    } else {
+      SqlDialectFactory factory = AvaticaUtils.instantiatePlugin(
+          SqlDialectFactory.class, sqlDialectFactory);
+      return JdbcSchema.create(
+          parentSchema, name, dataSource, factory, jdbcCatalog, jdbcSchema);
+    }
+  }
+
+  /**
+   * Returns a suitable SQL dialect for the given data source.
+   *
+   * @param dataSource The data source
+   *
+   * @deprecated Use {@link #createDialect(SqlDialectFactory, DataSource)} instead
+   */
+  @Deprecated // to be removed before 2.0
+  public static SqlDialect createDialect(DataSource dataSource) {
+    return createDialect(SqlDialectFactoryImpl.INSTANCE, dataSource);
+  }
+
+  /** Returns a suitable SQL dialect for the given data source. */
+  public static SqlDialect createDialect(SqlDialectFactory dialectFactory,
+                                         DataSource dataSource) {
+    return JdbcUtils.DialectPool.INSTANCE.get(dialectFactory, dataSource);
+  }
+
+  /** Creates a JDBC data source with the given specification. */
+  public static DataSource dataSource(String url, @Nullable String driverClassName,
+                                      @Nullable String username, @Nullable String password) {
+    if (url.startsWith("jdbc:hsqldb:")) {
+      // Prevent hsqldb from screwing up java.util.logging.
+      System.setProperty("hsqldb.reconfig_logging", "false");
+    }
+    return JdbcUtils.DataSourcePool.INSTANCE.get(url, driverClassName, username,
+        password);
+  }
+
+  @Override public boolean isMutable() {
+    return false;
+  }
+
+  @Override public Schema snapshot(SchemaVersion version) {
+    return new JdbcSchema(dataSource, dialect, convention, catalog, schema,
+        tableMap);
+  }
+
+  // Used by generated code.
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  @Override public Expression getExpression(@Nullable SchemaPlus parentSchema, String name) {
+    requireNonNull(parentSchema, "parentSchema must not be null for JdbcSchema");
+    return Schemas.subSchemaExpression(parentSchema, name, JdbcSchema.class);
+  }
+
+  protected Multimap<String, Function> getFunctions() {
+    // TODO: populate map from JDBC metadata
+    return ImmutableMultimap.of();
+  }
+
+  @Override public final Collection<Function> getFunctions(String name) {
+    return getFunctions().get(name); // never null
+  }
+
+  @Override public final Set<String> getFunctionNames() {
+    return getFunctions().keySet();
+  }
+
+  private ImmutableMap<String, JdbcTable> computeTables() {
+    Connection connection = null;
+    ResultSet resultSet = null;
+    try {
+      connection = dataSource.getConnection();
+      final Pair<@Nullable String, @Nullable String> catalogSchema = getCatalogSchema(connection);
+      final String catalog = catalogSchema.left;
+      final String schema = catalogSchema.right;
+      final Iterable<MetaImpl.MetaTable> tableDefs;
+      Foo threadMetadata = THREAD_METADATA.get();
+      if (threadMetadata != null) {
+        tableDefs = threadMetadata.apply(catalog, schema);
+      } else {
+        final List<MetaImpl.MetaTable> tableDefList = new ArrayList<>();
+        final DatabaseMetaData metaData = connection.getMetaData();
+        resultSet = metaData.getTables(catalog, schema, null, null);
+        while (resultSet.next()) {
+          final String catalogName = resultSet.getString(1);
+          final String schemaName = resultSet.getString(2);
+          final String tableName = resultSet.getString(3);
+          final String tableTypeName = resultSet.getString(4);
+          tableDefList.add(
+              new MetaImpl.MetaTable(catalogName, schemaName, tableName,
+                  tableTypeName));
+        }
+        tableDefs = tableDefList;
+      }
+
+      final ImmutableMap.Builder<String, JdbcTable> builder =
+          ImmutableMap.builder();
+      for (MetaImpl.MetaTable tableDef : tableDefs) {
+        // Clean up table type. In particular, this ensures that 'SYSTEM TABLE',
+        // returned by Phoenix among others, maps to TableType.SYSTEM_TABLE.
+        // We know enum constants are upper-case without spaces, so we can't
+        // make things worse.
+        //
+        // PostgreSQL returns tableTypeName==null for pg_toast* tables
+        // This can happen if you start JdbcSchema off a "public" PG schema
+        // The tables are not designed to be queried by users, however we do
+        // not filter them as we keep all the other table types.
+        final String tableTypeName2 =
+            tableDef.tableType == null
+            ? null
+            : tableDef.tableType.toUpperCase(Locale.ROOT).replace(' ', '_');
+        final TableType tableType =
+            Util.enumVal(TableType.OTHER, tableTypeName2);
+        if (tableType == TableType.OTHER  && tableTypeName2 != null) {
+          System.out.println("Unknown table type: " + tableTypeName2);
+        }
+        final JdbcTable table =
+            new JdbcTable(this, tableDef.tableCat, tableDef.tableSchem,
+                tableDef.tableName, tableType);
+        builder.put(tableDef.tableName, table);
+      }
+      return builder.build();
+    } catch (SQLException e) {
+      throw new RuntimeException(
+          "Exception while reading tables", e);
+    } finally {
+      close(connection, null, resultSet);
+    }
+  }
+
+  /** Returns [major, minor] version from a database metadata. */
+  private static List<Integer> version(DatabaseMetaData metaData) throws SQLException {
+    return ImmutableList.of(metaData.getJDBCMajorVersion(),
+        metaData.getJDBCMinorVersion());
+  }
+
+  /** Returns a pair of (catalog, schema) for the current connection. */
+  private Pair<@Nullable String, @Nullable String> getCatalogSchema(Connection connection)
+      throws SQLException {
+    final DatabaseMetaData metaData = connection.getMetaData();
+    final List<Integer> version41 = ImmutableList.of(4, 1); // JDBC 4.1
+    String catalog = this.catalog;
+    String schema = this.schema;
+    final boolean jdbc41OrAbove =
+        VERSION_ORDERING.compare(version(metaData), version41) >= 0;
+    if (catalog == null && jdbc41OrAbove) {
+      // From JDBC 4.1, catalog and schema can be retrieved from the connection
+      // object, hence try to get it from there if it was not specified by user
+      catalog = connection.getCatalog();
+    }
+    if (schema == null && jdbc41OrAbove) {
+      schema = connection.getSchema();
+      if ("".equals(schema)) {
+        schema = null; // PostgreSQL returns useless "" sometimes
+      }
+    }
+    if ((catalog == null || schema == null)
+        && metaData.getDatabaseProductName().equals("PostgreSQL")) {
+      final String sql = "select current_database(), current_schema()";
+      try (Statement statement = connection.createStatement();
+           ResultSet resultSet = statement.executeQuery(sql)) {
+        if (resultSet.next()) {
+          catalog = resultSet.getString(1);
+          schema = resultSet.getString(2);
+        }
+      }
+    }
+    return Pair.of(catalog, schema);
+  }
+
+  @Override public @Nullable Table getTable(String name) {
+    return getTableMap(false).get(name);
+  }
+
+  private synchronized ImmutableMap<String, JdbcTable> getTableMap(
+      boolean force) {
+    if (force || tableMap == null) {
+      tableMap = computeTables();
+    }
+    return tableMap;
+  }
+
+  RelProtoDataType getRelDataType(String catalogName, String schemaName,
+                                  String tableName) throws SQLException {
+    Connection connection = null;
+    try {
+      connection = dataSource.getConnection();
+      DatabaseMetaData metaData = connection.getMetaData();
+      return getRelDataType(metaData, catalogName, schemaName, tableName);
+    } finally {
+      close(connection, null, null);
+    }
+  }
+
+  RelProtoDataType getRelDataType(DatabaseMetaData metaData, String catalogName,
+                                  String schemaName, String tableName) throws SQLException {
+    final ResultSet resultSet =
+        metaData.getColumns(catalogName, schemaName, tableName, null);
+
+    // Temporary type factory, just for the duration of this method. Allowable
+    // because we're creating a proto-type, not a type; before being used, the
+    // proto-type will be copied into a real type factory.
+    final RelDataTypeFactory typeFactory =
+        new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+    final RelDataTypeFactory.Builder fieldInfo = typeFactory.builder();
+    while (resultSet.next()) {
+      final String columnName = requireNonNull(resultSet.getString(4), "columnName");
+      final int dataType = resultSet.getInt(5);
+      final String typeString = resultSet.getString(6);
+      final int precision;
+      final int scale;
+      switch (SqlType.valueOf(dataType)) {
+      case TIMESTAMP:
+      case TIME:
+        precision = resultSet.getInt(9); // SCALE
+        scale = 0;
+        break;
+      default:
+        precision = resultSet.getInt(7); // SIZE
+        scale = resultSet.getInt(9); // SCALE
+        break;
+      }
+      RelDataType sqlType =
+          sqlType(typeFactory, dataType, precision, scale, typeString);
+      boolean nullable = resultSet.getInt(11) != DatabaseMetaData.columnNoNulls;
+      fieldInfo.add(columnName, sqlType).nullable(nullable);
+    }
+    resultSet.close();
+    return RelDataTypeImpl.proto(fieldInfo.build());
+  }
+
+  private static RelDataType sqlType(RelDataTypeFactory typeFactory, int dataType,
+                                     int precision, int scale, @Nullable String typeString) {
+    // Fall back to ANY if type is unknown
+    final SqlTypeName sqlTypeName =
+        Util.first(SqlTypeName.getNameForJdbcType(dataType), SqlTypeName.ANY);
+    switch (sqlTypeName) {
+    case ARRAY:
+      RelDataType component = null;
+      if (typeString != null && typeString.endsWith(" ARRAY")) {
+        // E.g. hsqldb gives "INTEGER ARRAY", so we deduce the component type
+        // "INTEGER".
+        final String remaining = typeString.substring(0,
+            typeString.length() - " ARRAY".length());
+        component = parseTypeString(typeFactory, remaining);
+      }
+      if (component == null) {
+        component = typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.ANY), true);
+      }
+      return typeFactory.createArrayType(component, -1);
+    default:
+      break;
+    }
+    if (precision >= 0
+        && scale >= 0
+        && sqlTypeName.allowsPrecScale(true, true)) {
+      return typeFactory.createSqlType(sqlTypeName, precision, scale);
+    } else if (precision >= 0 && sqlTypeName.allowsPrecNoScale()) {
+      return typeFactory.createSqlType(sqlTypeName, precision);
+    } else {
+      assert sqlTypeName.allowsNoPrecNoScale();
+      return typeFactory.createSqlType(sqlTypeName);
+    }
+  }
+
+  /** Given "INTEGER", returns BasicSqlType(INTEGER).
+   * Given "VARCHAR(10)", returns BasicSqlType(VARCHAR, 10).
+   * Given "NUMERIC(10, 2)", returns BasicSqlType(NUMERIC, 10, 2). */
+  private static RelDataType parseTypeString(RelDataTypeFactory typeFactory,
+                                             String typeString) {
+    int precision = -1;
+    int scale = -1;
+    int open = typeString.indexOf("(");
+    if (open >= 0) {
+      int close = typeString.indexOf(")", open);
+      if (close >= 0) {
+        String rest = typeString.substring(open + 1, close);
+        typeString = typeString.substring(0, open);
+        int comma = rest.indexOf(",");
+        if (comma >= 0) {
+          precision = Integer.parseInt(rest.substring(0, comma));
+          scale = Integer.parseInt(rest.substring(comma));
+        } else {
+          precision = Integer.parseInt(rest);
+        }
+      }
+    }
+    try {
+      final SqlTypeName typeName = SqlTypeName.valueOf(typeString);
+      return typeName.allowsPrecScale(true, true)
+          ? typeFactory.createSqlType(typeName, precision, scale)
+          : typeName.allowsPrecScale(true, false)
+          ? typeFactory.createSqlType(typeName, precision)
+          : typeFactory.createSqlType(typeName);
+    } catch (IllegalArgumentException e) {
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlType(SqlTypeName.ANY), true);
+    }
+  }
+
+  @Override public Set<String> getTableNames() {
+    // This method is called during a cache refresh. We can take it as a signal
+    // that we need to re-build our own cache.
+    return getTableMap(!snapshot).keySet();
+  }
+
+  protected Map<String, RelProtoDataType> getTypes() {
+    // TODO: populate map from JDBC metadata
+    return ImmutableMap.of();
+  }
+
+  @Override public @Nullable RelProtoDataType getType(String name) {
+    return getTypes().get(name);
+  }
+
+  @Override public Set<String> getTypeNames() {
+    //noinspection RedundantCast
+    return (Set<String>) getTypes().keySet();
+  }
+
+  @Override public @Nullable Schema getSubSchema(String name) {
+    // JDBC does not support sub-schemas.
+    return null;
+  }
+
+  @Override public Set<String> getSubSchemaNames() {
+    return ImmutableSet.of();
+  }
+
+  private static void close(
+      @Nullable Connection connection,
+      @Nullable Statement statement,
+      @Nullable ResultSet resultSet) {
+    if (resultSet != null) {
+      try {
+        resultSet.close();
+      } catch (SQLException e) {
+        // ignore
+      }
+    }
+    if (statement != null) {
+      try {
+        statement.close();
+      } catch (SQLException e) {
+        // ignore
+      }
+    }
+    if (connection != null) {
+      try {
+        connection.close();
+      } catch (SQLException e) {
+        // ignore
+      }
+    }
+  }
+
+  /** Schema factory that creates a
+   * {@link org.apache.calcite.adapter.jdbc.JdbcSchema}.
+   *
+   * <p>This allows you to create a jdbc schema inside a model.json file, like
+   * this:
+   *
+   * <blockquote><pre>
+   * {
+   *   "version": "1.0",
+   *   "defaultSchema": "FOODMART_CLONE",
+   *   "schemas": [
+   *     {
+   *       "name": "FOODMART_CLONE",
+   *       "type": "custom",
+   *       "factory": "org.apache.calcite.adapter.jdbc.JdbcSchema$Factory",
+   *       "operand": {
+   *         "jdbcDriver": "com.mysql.jdbc.Driver",
+   *         "jdbcUrl": "jdbc:mysql://localhost/foodmart",
+   *         "jdbcUser": "foodmart",
+   *         "jdbcPassword": "foodmart"
+   *       }
+   *     }
+   *   ]
+   * }</pre></blockquote>
+   */
+  public static class Factory implements SchemaFactory {
+    public static final Factory INSTANCE = new Factory();
+
+    private Factory() {}
+
+    @Override public Schema create(
+        SchemaPlus parentSchema,
+        String name,
+        Map<String, Object> operand) {
+      return JdbcSchema.create(parentSchema, name, operand);
+    }
+  }
+
+  /** Do not use. */
+  @Experimental
+  public interface Foo
+      extends BiFunction<@Nullable String, @Nullable String, Iterable<MetaImpl.MetaTable>> {
+  }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcTable.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcTable.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wayang.api.sql.calcite.jdbc;
+
+import com.google.common.base.Suppliers;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.java.AbstractQueryableTable;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+//import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.adapter.jdbc.JdbcTableScan;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.QueryProvider;
+import org.apache.calcite.linq4j.Queryable;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.prepare.Prepare.CatalogReader;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.core.TableModify.Operation;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.ResultSetEnumerable;
+import org.apache.calcite.schema.*;
+import org.apache.calcite.schema.impl.AbstractTableQueryable;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWriterConfig;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.util.SqlString;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Queryable that gets its data from a table within a JDBC connection.
+ *
+ * <p>The idea is not to read the whole table, however. The idea is to use
+ * this as a building block for a query, by applying Queryable operators
+ * such as
+ * {@link Queryable#where(org.apache.calcite.linq4j.function.Predicate2)}.
+ * The resulting queryable can then be converted to a SQL query, which can be
+ * executed efficiently on the JDBC server.</p>
+ */
+public class JdbcTable extends AbstractQueryableTable
+    implements TranslatableTable, ScannableTable, ModifiableTable {
+  @SuppressWarnings("methodref.receiver.bound.invalid")
+  private final Supplier<RelProtoDataType> protoRowTypeSupplier =
+      Suppliers.memoize(this::supplyProto)::get;
+  public final JdbcSchema jdbcSchema;
+  public final String jdbcCatalogName;
+  public final String jdbcSchemaName;
+  public final String jdbcTableName;
+  public final Schema.TableType jdbcTableType;
+
+  JdbcTable(JdbcSchema jdbcSchema, String jdbcCatalogName,
+            String jdbcSchemaName, String jdbcTableName,
+            Schema.TableType jdbcTableType) {
+    super(Object[].class);
+    this.jdbcSchema = requireNonNull(jdbcSchema, "jdbcSchema");
+    this.jdbcCatalogName = jdbcCatalogName;
+    this.jdbcSchemaName = jdbcSchemaName;
+    this.jdbcTableName = requireNonNull(jdbcTableName, "jdbcTableName");
+    this.jdbcTableType = requireNonNull(jdbcTableType, "jdbcTableType");
+  }
+
+  @Override public String toString() {
+    return "JdbcTable {" + jdbcTableName + "}";
+  }
+
+  @Override public Schema.TableType getJdbcTableType() {
+    return jdbcTableType;
+  }
+
+  @Override public <C extends Object> @Nullable C unwrap(Class<C> aClass) {
+    if (aClass.isInstance(jdbcSchema.getDataSource())) {
+      return aClass.cast(jdbcSchema.getDataSource());
+    } else if (aClass.isInstance(jdbcSchema.dialect)) {
+      return aClass.cast(jdbcSchema.dialect);
+    } else {
+      return super.unwrap(aClass);
+    }
+  }
+
+  @Override public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    return protoRowTypeSupplier.get().apply(typeFactory);
+  }
+
+  private RelProtoDataType supplyProto() {
+    try {
+      return jdbcSchema.getRelDataType(
+          jdbcCatalogName,
+          jdbcSchemaName,
+          jdbcTableName);
+    } catch (SQLException e) {
+      throw new RuntimeException(
+          "Exception while reading definition of table '" + jdbcTableName
+              + "'", e);
+    }
+  }
+
+  private List<Pair<ColumnMetaData.Rep, Integer>> fieldClasses(
+      final JavaTypeFactory typeFactory) {
+    final RelDataType rowType = getRowType(typeFactory);
+    return Util.transform(rowType.getFieldList(), f -> {
+      final RelDataType type = f.getType();
+      final Class clazz = (Class) typeFactory.getJavaClass(type);
+      final ColumnMetaData.Rep rep =
+          Util.first(ColumnMetaData.Rep.of(clazz),
+              ColumnMetaData.Rep.OBJECT);
+      return Pair.of(rep, type.getSqlTypeName().getJdbcOrdinal());
+    });
+  }
+
+  SqlString generateSql() {
+    final SqlNodeList selectList = SqlNodeList.SINGLETON_STAR;
+    SqlSelect node =
+        new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList,
+            tableName(), null, null, null, null, null, null, null, null);
+    final SqlWriterConfig config = SqlPrettyWriter.config()
+        .withAlwaysUseParentheses(true)
+        .withDialect(jdbcSchema.dialect);
+    final SqlPrettyWriter writer = new SqlPrettyWriter(config);
+    node.unparse(writer, 0, 0);
+    return writer.toSqlString();
+  }
+
+  /** Returns the table name, qualified with catalog and schema name if
+   * applicable, as a parse tree node ({@link SqlIdentifier}). */
+  public SqlIdentifier tableName() {
+    final List<String> names = new ArrayList<>(3);
+    if (jdbcSchema.catalog != null) {
+      names.add(jdbcSchema.catalog);
+    }
+    if (jdbcSchema.schema != null) {
+      names.add(jdbcSchema.schema);
+    }
+    names.add(jdbcTableName);
+    return new SqlIdentifier(names, SqlParserPos.ZERO);
+  }
+
+  @Override public RelNode toRel(RelOptTable.ToRelContext context,
+                                 RelOptTable relOptTable) {
+    /*return new JdbcTableScan(context.getCluster(), context.getTableHints(), relOptTable, this,
+        jdbcSchema.convention);*/
+    return LogicalTableScan.create(context.getCluster(), relOptTable, context.getTableHints());
+  }
+
+  @Override public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
+                                                SchemaPlus schema, String tableName) {
+    return new JdbcTableQueryable<>(queryProvider, schema, tableName);
+  }
+
+  @Override public Enumerable<@Nullable Object[]> scan(DataContext root) {
+    JavaTypeFactory typeFactory = root.getTypeFactory();
+    final SqlString sql = generateSql();
+    return ResultSetEnumerable.of(jdbcSchema.getDataSource(), sql.getSql(),
+        JdbcUtils.rowBuilderFactory2(fieldClasses(typeFactory)));
+  }
+
+  @Override public @Nullable Collection getModifiableCollection() {
+    return null;
+  }
+
+  @Override public TableModify toModificationRel(RelOptCluster cluster,
+                                                 RelOptTable table, CatalogReader catalogReader, RelNode input,
+                                                 Operation operation, @Nullable List<String> updateColumnList,
+                                                 @Nullable List<RexNode> sourceExpressionList, boolean flattened) {
+    jdbcSchema.convention.register(cluster.getPlanner());
+
+    return new LogicalTableModify(cluster, cluster.traitSetOf(Convention.NONE),
+        table, catalogReader, input, operation, updateColumnList,
+        sourceExpressionList, flattened);
+  }
+
+  /** Enumerable that returns the contents of a {@link JdbcTable} by connecting
+   * to the JDBC data source.
+   *
+   * @param <T> element type */
+  private class JdbcTableQueryable<T> extends AbstractTableQueryable<T> {
+    JdbcTableQueryable(QueryProvider queryProvider, SchemaPlus schema,
+                       String tableName) {
+      super(queryProvider, schema, JdbcTable.this, tableName);
+    }
+
+    @Override public String toString() {
+      return "JdbcTableQueryable {table: " + tableName + "}";
+    }
+
+    @Override public Enumerator<T> enumerator() {
+      final JavaTypeFactory typeFactory =
+          ((CalciteConnection) queryProvider).getTypeFactory();
+      final SqlString sql = generateSql();
+      final List<Pair<ColumnMetaData.Rep, Integer>> pairs =
+          fieldClasses(typeFactory);
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      final Enumerable<T> enumerable =
+          (Enumerable) ResultSetEnumerable.of(jdbcSchema.getDataSource(),
+              sql.getSql(), JdbcUtils.rowBuilderFactory2(pairs));
+      return enumerable.enumerator();
+    }
+  }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/jdbc/JdbcUtils.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.wayang.api.sql.calcite.jdbc;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.primitives.Ints;
+import org.apache.calcite.avatica.ColumnMetaData;
+import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.linq4j.function.Function0;
+import org.apache.calcite.linq4j.function.Function1;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlDialectFactory;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Utilities for the JDBC provider.
+ */
+final class JdbcUtils {
+  private JdbcUtils() {
+    throw new AssertionError("no instances!");
+  }
+
+  /** Returns a function that, given a {@link ResultSet}, returns a function
+   * that will yield successive rows from that result set. */
+  static Function1<ResultSet, Function0<@Nullable Object[]>> rowBuilderFactory(
+      final List<Pair<ColumnMetaData.Rep, Integer>> list) {
+    ColumnMetaData.Rep[] reps =
+        Pair.left(list).toArray(new ColumnMetaData.Rep[0]);
+    int[] types = Ints.toArray(Pair.right(list));
+    return resultSet -> new ObjectArrayRowBuilder1(resultSet, reps, types);
+  }
+
+  /** Returns a function that, given a {@link ResultSet}, returns a function
+   * that will yield successive rows from that result set;
+   * as {@link #rowBuilderFactory(List)} except that values are in Calcite's
+   * internal format (e.g. DATE represented as int). */
+  static Function1<ResultSet, Function0<@Nullable Object[]>> rowBuilderFactory2(
+      final List<Pair<ColumnMetaData.Rep, Integer>> list) {
+    ColumnMetaData.Rep[] reps =
+        Pair.left(list).toArray(new ColumnMetaData.Rep[0]);
+    int[] types = Ints.toArray(Pair.right(list));
+    return resultSet -> new ObjectArrayRowBuilder2(resultSet, reps, types);
+  }
+
+  /** Pool of dialects. */
+  static class DialectPool {
+    public static final DialectPool INSTANCE = new DialectPool();
+
+    private final LoadingCache<Pair<SqlDialectFactory, DataSource>, SqlDialect> cache =
+        CacheBuilder.newBuilder().softValues()
+            .build(CacheLoader.from(DialectPool::dialect));
+
+    private static SqlDialect dialect(
+        Pair<SqlDialectFactory, DataSource> key) {
+      SqlDialectFactory dialectFactory = key.left;
+      DataSource dataSource = key.right;
+      Connection connection = null;
+      try {
+        connection = dataSource.getConnection();
+        DatabaseMetaData metaData = connection.getMetaData();
+        SqlDialect dialect = dialectFactory.create(metaData);
+        connection.close();
+        connection = null;
+        return dialect;
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      } finally {
+        if (connection != null) {
+          try {
+            connection.close();
+          } catch (SQLException e) {
+            // ignore
+          }
+        }
+      }
+    }
+
+    public SqlDialect get(SqlDialectFactory dialectFactory, DataSource dataSource) {
+      final Pair<SqlDialectFactory, DataSource> key =
+          Pair.of(dialectFactory, dataSource);
+      return cache.getUnchecked(key);
+    }
+  }
+
+  /** Builder that calls {@link ResultSet#getObject(int)} for every column,
+   * or {@code getXxx} if the result type is a primitive {@code xxx},
+   * and returns an array of objects for each row. */
+  abstract static class ObjectArrayRowBuilder
+      implements Function0<@Nullable Object[]> {
+    protected final ResultSet resultSet;
+    protected final int columnCount;
+    protected final ColumnMetaData.Rep[] reps;
+    protected final int[] types;
+
+    ObjectArrayRowBuilder(ResultSet resultSet, ColumnMetaData.Rep[] reps,
+        int[] types) {
+      this.resultSet = resultSet;
+      this.reps = reps;
+      this.types = types;
+      try {
+        this.columnCount = resultSet.getMetaData().getColumnCount();
+      } catch (SQLException e) {
+        throw Util.throwAsRuntime(e);
+      }
+    }
+
+    @Override public @Nullable Object[] apply() {
+      try {
+        final @Nullable Object[] values = new Object[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+          values[i] = value(i);
+        }
+        return values;
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    /**
+     * Gets a value from a given column in a JDBC result set.
+     *
+     * @param i Ordinal of column (1-based, per JDBC)
+     */
+    protected abstract @Nullable Object value(int i) throws SQLException;
+
+    long timestampToLong(Timestamp v) {
+      return v.getTime();
+    }
+
+    long timeToLong(Time v) {
+      return v.getTime();
+    }
+
+    long dateToLong(Date v) {
+      return v.getTime();
+    }
+  }
+
+  /** Row builder that shifts DATE, TIME, TIMESTAMP values into local time
+   * zone. */
+  static class ObjectArrayRowBuilder1 extends ObjectArrayRowBuilder {
+    final TimeZone timeZone = TimeZone.getDefault();
+
+    ObjectArrayRowBuilder1(ResultSet resultSet, ColumnMetaData.Rep[] reps,
+        int[] types) {
+      super(resultSet, reps, types);
+    }
+
+    @Override protected @Nullable Object value(int i) throws SQLException {
+      // MySQL returns timestamps shifted into local time. Using
+      // getTimestamp(int, Calendar) with a UTC calendar should prevent this,
+      // but does not. So we shift explicitly.
+      switch (types[i]) {
+      case Types.TIMESTAMP:
+        final Timestamp timestamp = resultSet.getTimestamp(i + 1);
+        return timestamp == null ? null : new Timestamp(timestampToLong(timestamp));
+      case Types.TIME:
+        final Time time = resultSet.getTime(i + 1);
+        return time == null ? null : new Time(timeToLong(time));
+      case Types.DATE:
+        final Date date = resultSet.getDate(i + 1);
+        return date == null ? null : new Date(dateToLong(date));
+      default:
+        break;
+      }
+      return reps[i].jdbcGet(resultSet, i + 1);
+    }
+
+    @Override long timestampToLong(Timestamp v) {
+      long time = v.getTime();
+      int offset = timeZone.getOffset(time);
+      return time + offset;
+    }
+
+    @Override long timeToLong(Time v) {
+      long time = v.getTime();
+      int offset = timeZone.getOffset(time);
+      return (time + offset) % DateTimeUtils.MILLIS_PER_DAY;
+    }
+
+    @Override long dateToLong(Date v) {
+      long time = v.getTime();
+      int offset = timeZone.getOffset(time);
+      return time + offset;
+    }
+  }
+
+  /** Row builder that converts JDBC values into internal values. */
+  static class ObjectArrayRowBuilder2 extends ObjectArrayRowBuilder1 {
+    ObjectArrayRowBuilder2(ResultSet resultSet, ColumnMetaData.Rep[] reps,
+        int[] types) {
+      super(resultSet, reps, types);
+    }
+
+    @Override protected @Nullable Object value(int i) throws SQLException {
+      switch (types[i]) {
+      case Types.TIMESTAMP:
+        final Timestamp timestamp = resultSet.getTimestamp(i + 1);
+        return timestamp == null ? null : timestampToLong(timestamp);
+      case Types.TIME:
+        final Time time = resultSet.getTime(i + 1);
+        return time == null ? null : (int) timeToLong(time);
+      case Types.DATE:
+        final Date date = resultSet.getDate(i + 1);
+        return date == null ? null
+            : (int) (dateToLong(date) / DateTimeUtils.MILLIS_PER_DAY);
+      default:
+        return reps[i].jdbcGet(resultSet, i + 1);
+      }
+    }
+  }
+
+  /** Ensures that if two data sources have the same definition, they will use
+   * the same object.
+   *
+   * <p>This in turn makes it easier to cache
+   * {@link SqlDialect} objects. Otherwise, each time we
+   * see a new data source, we have to open a connection to find out what
+   * database product and version it is. */
+  static class DataSourcePool {
+    public static final DataSourcePool INSTANCE = new DataSourcePool();
+
+    private final LoadingCache<List<@Nullable String>, BasicDataSource> cache =
+        CacheBuilder.newBuilder().softValues()
+            .build(CacheLoader.from(DataSourcePool::dataSource));
+
+    private static BasicDataSource dataSource(
+          List<? extends @Nullable String> key) {
+      BasicDataSource dataSource = new BasicDataSource();
+      dataSource.setUrl(key.get(0));
+      dataSource.setUsername(key.get(1));
+      dataSource.setPassword(key.get(2));
+      dataSource.setDriverClassName(key.get(3));
+      return dataSource;
+    }
+
+    public DataSource get(String url, @Nullable String driverClassName,
+                          @Nullable String username, @Nullable String password) {
+      // Get data source objects from a cache, so that we don't have to sniff
+      // out what kind of database they are quite as often.
+      final List<@Nullable String> key =
+          ImmutableNullableList.of(url, username, password, driverClassName);
+      return cache.getUnchecked(key);
+    }
+  }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
@@ -1,0 +1,244 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.adapter.file.FileRules;
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.config.CalciteConnectionProperty;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.plan.*;
+import org.apache.calcite.plan.volcano.VolcanoPlanner;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.sql2rel.StandardConvertletTable;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.apache.calcite.tools.RuleSet;
+import org.apache.calcite.tools.RuleSets;
+import org.apache.wayang.api.sql.calcite.converter.WayangRelConverter;
+import org.apache.wayang.api.sql.calcite.schema.WayangSchema;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.LocalCallbackSink;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.apache.wayang.core.util.WayangCollections;
+
+import java.util.*;
+
+public class Optimizer {
+
+    private final CalciteConnectionConfig config;
+    private final SqlValidator sqlValidator;
+    private final SqlToRelConverter sqlToRelConverter;
+    private final VolcanoPlanner volcanoPlanner;
+
+    public Optimizer(
+            CalciteConnectionConfig config,
+            SqlValidator sqlValidator,
+            SqlToRelConverter sqlToRelConverter,
+            VolcanoPlanner volcanoPlanner) {
+        this.config = config;
+        this.sqlValidator = sqlValidator;
+        this.sqlToRelConverter = sqlToRelConverter;
+        this.volcanoPlanner = volcanoPlanner;
+    }
+
+    public static Optimizer create(
+            CalciteSchema calciteSchema,
+            Properties configProperties,
+            RelDataTypeFactory typeFactory) {
+
+        CalciteConnectionConfig config = new CalciteConnectionConfigImpl(configProperties);
+
+        CalciteCatalogReader catalogReader = new CalciteCatalogReader(
+                calciteSchema.root(),
+                ImmutableList.of(calciteSchema.name),
+                typeFactory,
+                config
+        );
+
+        SqlOperatorTable operatorTable = new ChainedSqlOperatorTable(ImmutableList.of(SqlStdOperatorTable.instance()));
+
+        SqlValidator.Config validatorConfig = SqlValidator.Config.DEFAULT
+                .withLenientOperatorLookup(config.lenientOperatorLookup())
+                .withSqlConformance(config.conformance())
+                .withDefaultNullCollation(config.defaultNullCollation())
+                .withIdentifierExpansion(true);
+
+        SqlValidator validator = SqlValidatorUtil.newValidator(operatorTable, catalogReader, typeFactory, validatorConfig);
+
+        VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.of(config));
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+        RelOptCluster cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+
+        SqlToRelConverter.Config converterConfig = SqlToRelConverter.config()
+                .withTrimUnusedFields(true)
+                .withExpand(false);
+
+        SqlToRelConverter converter = new SqlToRelConverter(
+                null,
+                validator,
+                catalogReader,
+                cluster,
+                StandardConvertletTable.INSTANCE,
+                converterConfig
+        );
+
+        return new Optimizer(config, validator, converter, planner);
+    }
+
+
+
+    //To remove
+    public static Optimizer create(WayangSchema wayangSchema) {
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+
+        // Configuration
+        Properties configProperties = new Properties();
+        configProperties.put(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.TRUE.toString());
+        configProperties.put(CalciteConnectionProperty.UNQUOTED_CASING.camelName(), Casing.UNCHANGED.toString());
+        configProperties.put(CalciteConnectionProperty.QUOTED_CASING.camelName(), Casing.UNCHANGED.toString());
+
+        CalciteConnectionConfig config = new CalciteConnectionConfigImpl(configProperties);
+
+        CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false);
+        rootSchema.add(wayangSchema.getSchemaName(), wayangSchema);
+        Prepare.CatalogReader catalogReader = new CalciteCatalogReader(
+                rootSchema,
+                Collections.singletonList(wayangSchema.getSchemaName()),
+                typeFactory,
+                config
+        );
+
+        SqlOperatorTable operatorTable = new ChainedSqlOperatorTable(ImmutableList.of(SqlStdOperatorTable.instance()));
+
+        SqlValidator.Config validatorConfig = SqlValidator.Config.DEFAULT
+                .withLenientOperatorLookup(config.lenientOperatorLookup())
+                .withSqlConformance(config.conformance())
+                .withDefaultNullCollation(config.defaultNullCollation())
+                .withIdentifierExpansion(true);
+
+        SqlValidator validator = SqlValidatorUtil.newValidator(operatorTable, catalogReader, typeFactory, validatorConfig);
+
+        VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.of(config));
+        planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+
+        RelOptCluster cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+
+        SqlToRelConverter.Config converterConfig = SqlToRelConverter.config()
+                .withTrimUnusedFields(true)
+                .withExpand(false);
+
+        SqlToRelConverter converter = new SqlToRelConverter(
+                null,
+                validator,
+                catalogReader,
+                cluster,
+                StandardConvertletTable.INSTANCE,
+                converterConfig
+        );
+
+        return new Optimizer(config, validator, converter, planner);
+    }
+
+
+    public SqlNode parseSql(String sql) throws Exception {
+        SqlParser.Config parserConfig = SqlParser.config()
+                .withCaseSensitive(config.caseSensitive())
+                .withQuotedCasing(config.quotedCasing())
+                .withUnquotedCasing(config.unquotedCasing())
+                .withConformance(config.conformance());
+
+        SqlParser parser = SqlParser.create(sql, parserConfig);
+
+        return parser.parseStmt();
+    }
+
+    public SqlNode validate(SqlNode sqlNode) {
+        return sqlValidator.validate(sqlNode);
+    }
+
+    public RelNode convert(SqlNode sqlNode) {
+        RelRoot root  = sqlToRelConverter.convertQuery(sqlNode, false, true);
+        return root.rel;
+    }
+
+    //TODO: create a basic ruleset
+    public RelNode optimize(RelNode node, RelTraitSet requiredTraitSet, RuleSet rules) {
+        Program program = Programs.of(RuleSets.ofList(rules));
+
+        return program.run(
+                volcanoPlanner,
+                node,
+                requiredTraitSet,
+                Collections.emptyList(),
+                Collections.emptyList()
+        );
+    }
+
+    public WayangPlan convert(RelNode relNode) {
+        return convert(relNode, new ArrayList<>());
+    }
+
+    public WayangPlan convert(RelNode relNode, Collection<Record> collector) {
+
+        LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
+
+        Operator op = new WayangRelConverter().convert(relNode);
+
+        op.connectTo(0, sink, 0);
+        return new WayangPlan(sink);
+    }
+
+
+    public static class ConfigProperties {
+
+        public static Properties getDefaults() {
+            Properties configProperties = new Properties();
+            configProperties.put(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), Boolean.TRUE.toString());
+            configProperties.put(CalciteConnectionProperty.UNQUOTED_CASING.camelName(), Casing.UNCHANGED.toString());
+            configProperties.put(CalciteConnectionProperty.QUOTED_CASING.camelName(), Casing.UNCHANGED.toString());
+            return configProperties;
+        }
+
+    }
+
+
+}
+
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.optimizer;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
@@ -18,7 +18,6 @@
 package org.apache.wayang.api.sql.calcite.optimizer;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.calcite.adapter.file.FileRules;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
@@ -52,9 +51,11 @@ import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.operators.LocalCallbackSink;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
-import org.apache.wayang.core.util.WayangCollections;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
 
 public class Optimizer {
 

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/WayangProgram.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/WayangProgram.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.optimizer;
+
+import org.apache.calcite.plan.*;
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.tools.Program;
+import org.apache.calcite.tools.Programs;
+import org.apache.calcite.tools.RuleSet;
+import org.apache.wayang.api.sql.calcite.rules.WayangRules;
+
+import java.util.List;
+
+public class WayangProgram implements Program {
+
+    private final RuleSet rules;
+
+    WayangProgram(RuleSet rules) {
+        this.rules = rules;
+    }
+
+    @Override
+    public RelNode run(RelOptPlanner relOptPlanner, RelNode relNode, RelTraitSet relTraitSet, List<RelOptMaterialization> list, List<RelOptLattice> list1) {
+
+        final HepProgramBuilder builder = HepProgram.builder();
+        for(RelOptRule rule : rules) {
+            builder.addRuleInstance(rule);
+        }
+        builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+
+        Program hep = Programs.of(builder.build(), false, null);
+        RelNode run = hep.run(relOptPlanner, relNode, relTraitSet, list, list1);
+
+        return run;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/WayangProgram.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/WayangProgram.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.optimizer;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangFilter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangFilter.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.rel;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangFilter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangFilter.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.rel;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.RexNode;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+
+public class WayangFilter extends Filter implements WayangRel {
+
+    public WayangFilter(
+            RelOptCluster cluster,
+            RelTraitSet traits,
+            RelNode child,
+            RexNode condition) {
+        super(cluster, traits, child, condition);
+        assert getConvention() instanceof WayangConvention;
+    }
+
+    @Override
+    public Filter copy(RelTraitSet traitSet, RelNode input, RexNode condition) {
+        return new WayangFilter(getCluster(), traitSet, input, condition);
+    }
+
+    @Override
+    public String toString() {
+        return "Wayang Filter";
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangJoin.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangJoin.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.rel;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangJoin.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangJoin.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.rel;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rex.RexNode;
+
+import java.util.Set;
+
+public class WayangJoin extends Join implements WayangRel {
+
+    public WayangJoin(
+            RelOptCluster cluster,
+            RelTraitSet traitSet,
+            RelNode left,
+            RelNode right,
+            RexNode condition,
+            Set<CorrelationId> variablesSet,
+            JoinRelType joinType) {
+        super(cluster, traitSet, ImmutableList.of(), left, right, condition, variablesSet, joinType);
+    }
+
+    @Override
+    public WayangJoin copy(
+            RelTraitSet relTraitSet,
+            RexNode condition,
+            RelNode left,
+            RelNode right,
+            JoinRelType joinType,
+            boolean semiJoinDone) {
+        return new WayangJoin(getCluster(), relTraitSet, left, right, condition, variablesSet, joinType);
+    }
+
+    @Override
+    public String toString() {
+        return "Wayang Join";
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangProject.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangProject.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.rel;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangProject.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangProject.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.rel;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+
+import java.util.List;
+
+public class WayangProject extends Project implements WayangRel {
+    public WayangProject(
+            RelOptCluster cluster,
+            RelTraitSet traits,
+            RelNode input,
+            List<? extends RexNode> projects,
+            RelDataType rowType) {
+        super(cluster, traits, ImmutableList.of(), input, projects, rowType);
+        assert getConvention() instanceof WayangConvention;
+    }
+
+    @Override
+    public WayangProject copy(RelTraitSet traitSet, RelNode input,
+                              List<RexNode> projects, RelDataType rowType) {
+        return new WayangProject(getCluster(), traitSet, input, projects, rowType);
+    }
+
+    @Override
+    public String toString() {
+        return "WayangProject";
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangRel.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangRel.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.wayang.api.sql.calcite.rel;
+
+import org.apache.calcite.rel.RelNode;
+
+public interface WayangRel extends RelNode {
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangRel.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangRel.java
@@ -1,13 +1,12 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.rel;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.rel;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.adapter.file.FileRules;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.schema.Table;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+
+import java.util.List;
+
+public class WayangTableScan extends TableScan implements WayangRel {
+
+    private final int[] fields;
+
+    public WayangTableScan(RelOptCluster cluster,
+                           RelTraitSet traitSet,
+                           List<RelHint> hints,
+                           RelOptTable table,
+                           int[] fields) {
+        super(cluster, traitSet, hints, table);
+        if(fields==null) {
+            int size = table.getRowType().getFieldCount();
+            fields = new int[size];
+            for (int i = 0; i < size; i++) {
+                fields[i] = i;
+            }
+        }
+        this.fields = fields;
+
+    }
+
+    public WayangTableScan(RelOptCluster cluster,
+                           RelTraitSet traitSet,
+                           List<RelHint> hints,
+                           RelOptTable table) {
+        this(cluster, traitSet, hints, table, null);
+    }
+
+    public static WayangTableScan create(RelOptCluster cluster, RelOptTable relOptTable) {
+        return create(cluster, relOptTable, null);
+    }
+
+
+    public static WayangTableScan create(RelOptCluster cluster, RelOptTable relOptTable, int[] fields) {
+        final Table table = relOptTable.unwrap(Table.class);
+        Class elementType = Object.class;
+        final RelTraitSet traitSet = cluster.traitSetOf(WayangConvention.INSTANCE)
+                .replaceIfs(RelCollationTraitDef.INSTANCE, () -> {
+                    if (table != null) {
+                        return table.getStatistic().getCollations();
+                    }
+                    return ImmutableList.of();
+                });
+        return new WayangTableScan(cluster, traitSet, ImmutableList.of(), relOptTable, fields);
+    }
+
+    @Override
+    public String toString() {
+        return "Wayang TableScan ["+ getQualifiedName() + "]";
+    }
+
+    public String getQualifiedName() {
+        return table.getQualifiedName().get(1);
+    }
+
+    public String getTableName() {
+        return table.getQualifiedName().get(1);
+    }
+
+    public List<String> getColumnNames() {
+        return table.getRowType().getFieldNames();
+    }
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
@@ -18,9 +18,7 @@
 package org.apache.wayang.api.sql.calcite.rel;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.calcite.adapter.file.FileRules;
 import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollationTraitDef;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.rules;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
@@ -17,23 +17,17 @@
 
 package org.apache.wayang.api.sql.calcite.rules;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
-import org.apache.calcite.adapter.file.CsvTableScan;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptTable;
-import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
-import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableScan;
-import org.apache.calcite.tools.RuleSet;
-import org.apache.calcite.tools.RuleSets;
 import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
 import org.apache.wayang.api.sql.calcite.rel.WayangFilter;
 import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
@@ -41,10 +35,8 @@ import org.apache.wayang.api.sql.calcite.rel.WayangProject;
 import org.apache.wayang.api.sql.calcite.rel.WayangTableScan;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 //TODO: split into multiple classes
 public class WayangRules {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangRules.java
@@ -1,0 +1,190 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.rules;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.file.CsvTableScan;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.tools.RuleSet;
+import org.apache.calcite.tools.RuleSets;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+import org.apache.wayang.api.sql.calcite.rel.WayangFilter;
+import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
+import org.apache.wayang.api.sql.calcite.rel.WayangProject;
+import org.apache.wayang.api.sql.calcite.rel.WayangTableScan;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+//TODO: split into multiple classes
+public class WayangRules {
+
+    private WayangRules(){
+    }
+
+
+    public static final RelOptRule WAYANG_JOIN_RULE = new WayangJoinRule(WayangJoinRule.DEFAULT_CONFIG);
+    public static final RelOptRule WAYANG_PROJECT_RULE = new WayangProjectRule(WayangProjectRule.DEFAULT_CONFIG);
+    public static final RelOptRule WAYANG_FILTER_RULE =  new WayangFilterRule(WayangFilterRule.DEFAULT_CONFIG);
+    public static final RelOptRule WAYANG_TABLESCAN_RULE = new WayangTableScanRule(WayangTableScanRule.DEFAULT_CONFIG);
+    public static final RelOptRule WAYANG_TABLESCAN_ENUMERABLE_RULE =
+            new WayangTableScanRule(WayangTableScanRule.ENUMERABLE_CONFIG);
+
+
+    private static class WayangProjectRule extends ConverterRule {
+
+        public static final Config DEFAULT_CONFIG = Config.INSTANCE
+                .withConversion(LogicalProject.class,
+                        Convention.NONE, WayangConvention.INSTANCE,
+                        "WayangProjectRule")
+                .withRuleFactory(WayangProjectRule::new);
+
+
+        protected WayangProjectRule(Config config) {
+            super(config);
+        }
+
+        public RelNode convert(RelNode rel) {
+            final LogicalProject project = (LogicalProject) rel;
+            return new WayangProject(
+                    project.getCluster(),
+                    project.getTraitSet().replace(WayangConvention.INSTANCE),
+                    convert(project.getInput(), project.getInput().getTraitSet()
+                            .replace(WayangConvention.INSTANCE)),
+                    project.getProjects(),
+                    project.getRowType());
+        }
+    }
+
+
+    private static class WayangFilterRule extends ConverterRule {
+
+        public static final Config DEFAULT_CONFIG = Config.INSTANCE
+                .withConversion(LogicalFilter.class,
+                        Convention.NONE, WayangConvention.INSTANCE,
+                        "WayangFilterRule")
+                .withRuleFactory(WayangFilterRule::new);
+
+
+        protected WayangFilterRule(Config config) {
+            super(config);
+        }
+
+        @Override
+        public RelNode convert(RelNode rel) {
+            final LogicalFilter filter = (LogicalFilter) rel;
+            return new WayangFilter(
+                    rel.getCluster(),
+                    rel.getTraitSet().replace(WayangConvention.INSTANCE),
+                    convert(filter.getInput(), filter.getInput().getTraitSet().
+                            replace(WayangConvention.INSTANCE)),
+                    filter.getCondition());
+        }
+
+    }
+
+    private static class WayangTableScanRule extends ConverterRule {
+
+        public static final Config DEFAULT_CONFIG = Config.INSTANCE
+                .withConversion(LogicalTableScan.class,
+                        Convention.NONE, WayangConvention.INSTANCE,
+                        "WayangTableScanRule")
+                .withRuleFactory(WayangTableScanRule::new);
+
+        public static final Config ENUMERABLE_CONFIG = Config.INSTANCE
+                .withConversion(TableScan.class,
+                        EnumerableConvention.INSTANCE, WayangConvention.INSTANCE,
+                        "WayangTableScanRule1")
+                .withRuleFactory(WayangTableScanRule::new);
+
+        protected WayangTableScanRule(Config config) {
+            super(config);
+        }
+
+        @Override
+        public @Nullable RelNode convert(RelNode relNode) {
+
+            TableScan scan = (TableScan) relNode;
+            final RelOptTable relOptTable = scan.getTable();
+
+            /**
+             * This is quick hack to prevent volcano from merging projects on to TableScans
+             * TODO: a cleaner way to handle this
+             */
+            if(relOptTable.getRowType() == scan.getRowType()) {
+                return WayangTableScan.create(scan.getCluster(), relOptTable);
+            }
+            return null;
+        }
+    }
+
+
+    private static class WayangJoinRule extends ConverterRule {
+
+        public static final Config DEFAULT_CONFIG = Config.INSTANCE
+                .withConversion(LogicalJoin.class, Convention.NONE,
+                        WayangConvention.INSTANCE, "WayangJoinRule")
+                .withRuleFactory(WayangJoinRule::new);
+
+        protected WayangJoinRule(Config config) {
+            super(config);
+        }
+
+        @Override
+        public @Nullable RelNode convert(RelNode relNode) {
+            LogicalJoin join = (LogicalJoin) relNode;
+            List<RelNode> newInputs = new ArrayList<>();
+            for(RelNode input : join.getInputs()) {
+                if(!(input.getConvention() instanceof WayangConvention)) {
+                    input = convert(input, input.getTraitSet().replace(WayangConvention.INSTANCE));
+                }
+                newInputs.add(input);
+            }
+
+            return new WayangJoin(
+                    join.getCluster(),
+                    join.getTraitSet().replace(WayangConvention.INSTANCE),
+                    newInputs.get(0),
+                    newInputs.get(1),
+                    join.getCondition(),
+                    join.getVariablesSet(),
+                    join.getJoinType()
+            );
+        }
+    }
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.wayang.core.api.Configuration;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * This class contains some hardcoded functions for creating calcite schema.
+ * TODO: Automatically create calcite schema based on user provided configurations of table sources
+ */
+public class SchemaUtils {
+
+    private static Properties getPostgresProperties() {
+        /** Hardcoded for testing **/
+        Properties info = new Properties();
+        info.put("model",
+                "inline:"
+                        + "{\n"
+                        + "  version: '1.0',\n"
+                        + "  defaultSchema: 'tpch',\n"
+                        + "  schemas: [\n"
+                        + "     {\n"
+                        + "       name: 'postgres',\n"
+                        + "       type: 'custom',\n"
+                        + "       factory: 'org.apache.wayang.api.sql.calcite.jdbc.JdbcSchema$Factory',\n"
+                        + "       operand: {\n"
+                        + "         jdbcDriver: 'org.postgresql.Driver',\n"
+                        + "         jdbcUrl: 'jdbc:postgresql://localhost:5432/tpch',\n"
+                        + "         jdbcUser: 'user',\n"
+                        + "         jdbcPassword: 'password'\n"
+                        + "       }\n"
+                        + "     }\n"
+                        + "  ]\n"
+                        + "}");
+        return info;
+    }
+
+    private static Properties getFileProperties() {
+        Properties info = new Properties();
+        info.put("model",
+                "inline:"
+                        + "{\n"
+                        + "  version: '1.0',\n"
+                        + "  defaultSchema: 'tpch',\n"
+                        + "  schemas: [ {\n"
+                        + "    name: 'fs',\n"
+                        + "    type: 'custom',\n"
+                        + "    factory: 'org.apache.calcite.adapter.file.FileSchemaFactory',\n"
+                        + "    operand: {\n"
+                        + "        directory: '/data/Projects/databloom/test-data'\n"
+                        + "      } \n"
+                        + "    }\n"
+                        + "  ]\n"
+                        + "}"
+        );
+        return info;
+    }
+
+
+    public static CalciteSchema getPostgresSchema(Configuration configuration) throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:calcite:", getPostgresProperties());
+        return getCalciteSchema(connection);
+    }
+
+    public static CalciteSchema getFileSchema(Configuration configuration) throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:calcite:", getFileProperties());
+        return getCalciteSchema(connection);
+    }
+
+    public static CalciteSchema getCalciteSchema(Connection connection) throws SQLException {
+            CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+            final SchemaPlus schemaPlus = calciteConnection.getRootSchema();
+            CalciteSchema calciteSchema = CalciteSchema.from(schemaPlus);
+            return calciteSchema;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchema.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchema.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchema.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchema.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaVersion;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
+import java.util.Map;
+
+public class WayangSchema extends AbstractSchema {
+
+    private final String schemaName;
+    private final Map<String, Table> tableMap;
+
+
+    public WayangSchema(String schemaName, Map<String, Table> tableMap) {
+        this.schemaName = schemaName;
+        this.tableMap = tableMap;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    @Override
+    protected Map<String, Table> getTableMap() {
+        return tableMap;
+    }
+
+    @Override
+    public Schema snapshot(SchemaVersion version) {
+        return this;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchemaBuilder.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchemaBuilder.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.schema.Table;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WayangSchemaBuilder {
+
+    private final String schemaName;
+    private final Map<String, Table> tableMap = new HashMap<>();
+
+    private WayangSchemaBuilder(String schemaName) {
+        if (schemaName == null || schemaName.isEmpty()) {
+            throw new IllegalArgumentException("Schema name cannot be null or empty");
+        }
+
+        this.schemaName = schemaName;
+    }
+
+    public static WayangSchemaBuilder build(String schemaName) {
+        return new WayangSchemaBuilder(schemaName);
+    }
+
+    public WayangSchemaBuilder addTable(WayangTable table) {
+        if (tableMap.containsKey(table.getTableName())) {
+            throw new IllegalArgumentException("Table already defined: " + table.getTableName());
+        }
+
+        tableMap.put(table.getTableName(), table);
+
+        return this;
+    }
+
+    public WayangSchema build() {
+        return new WayangSchema(schemaName, tableMap);
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchemaBuilder.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangSchemaBuilder.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTable.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTable.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTable.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTable.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.rel.type.*;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WayangTable extends AbstractTable {
+
+    private final String tableName;
+    private final List<String> fieldNames;
+    private final List<SqlTypeName> fieldTypes;
+    private final WayangTableStatistic statistic;
+
+    private RelDataType rowType;
+
+    public WayangTable(String tableName, List<String> fieldNames, List<SqlTypeName> fieldTypes, WayangTableStatistic statistic) {
+        this.tableName = tableName;
+        this.fieldNames = fieldNames;
+        this.fieldTypes = fieldTypes;
+        this.statistic = statistic;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
+        if(rowType == null) {
+            List<RelDataTypeField> fields = new ArrayList<>(fieldNames.size());
+
+            for(int i = 0; i < fieldNames.size(); i++) {
+                RelDataType fieldType = relDataTypeFactory.createSqlType(fieldTypes.get(i));
+                RelDataTypeField field = new RelDataTypeFieldImpl(fieldNames.get(i), i , fieldType);
+                fields.add(field);
+            }
+
+            rowType = new RelRecordType(StructKind.PEEK_FIELDS, fields, false);
+        }
+
+        return rowType;
+    }
+
+    @Override
+    public Statistic getStatistic() {
+        return statistic;
+    }
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableBuilder.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableBuilder.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableBuilder.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableBuilder.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WayangTableBuilder {
+
+    private final String tableName;
+    private final List<String> fieldNames = new ArrayList<>();
+    private final List<SqlTypeName> fieldTypes = new ArrayList<>();
+    private long rowCount;
+
+    private WayangTableBuilder(String tableName) {
+        if (tableName == null || tableName.isEmpty()) {
+            throw new IllegalArgumentException("Table name cannot be null or empty");
+        }
+
+        this.tableName = tableName;
+    }
+
+    public static WayangTableBuilder build(String tableName) {
+        return new WayangTableBuilder(tableName);
+    }
+
+    public WayangTableBuilder addField(String name, SqlTypeName typeName) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Field name cannot be null or empty");
+        }
+
+        if (fieldNames.contains(name)) {
+            throw new IllegalArgumentException("Field already defined: " + name);
+        }
+
+        fieldNames.add(name);
+        fieldTypes.add(typeName);
+
+        return this;
+    }
+
+    public WayangTableBuilder withRowCount(long rowCount) {
+        this.rowCount = rowCount;
+
+        return this;
+    }
+
+    public WayangTable build() {
+        if (fieldNames.isEmpty()) {
+            throw new IllegalStateException("Table must have at least one field");
+        }
+
+        if (rowCount == 0L) {
+            throw new IllegalStateException("Table must have positive row count");
+        }
+
+        return new WayangTable(tableName, fieldNames, fieldTypes, new WayangTableStatistic(rowCount));
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableStatistic.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableStatistic.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.schema;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableStatistic.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/WayangTableStatistic.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.schema;
+
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributionTraitDef;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WayangTableStatistic implements Statistic {
+    private final long rowCount;
+
+    public WayangTableStatistic(long rowCount) {
+        this.rowCount = rowCount;
+    }
+
+    @Override
+    public @Nullable Double getRowCount() {
+        return (double) rowCount;
+    }
+
+    @Override
+    public boolean isKey(ImmutableBitSet columns) {
+        return false;
+    }
+
+    @Override
+    public @Nullable List<ImmutableBitSet> getKeys() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable List<RelReferentialConstraint> getReferentialConstraints() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable List<RelCollation> getCollations() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public @Nullable RelDistribution getDistribution() {
+        return RelDistributionTraitDef.INSTANCE.getDefault();
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/PrintUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/PrintUtils.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.calcite.utils;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/PrintUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/PrintUtils.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.calcite.utils;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.externalize.RelWriterImpl;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.plan.wayangplan.PlanTraversal;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+
+public class PrintUtils {
+
+    public static void print(String header, WayangPlan plan) {
+        StringWriter sw = new StringWriter();
+        sw.append(header).append(":").append("\n");
+
+        final Collection<Operator> operators = PlanTraversal.upstream().traverse(plan.getSinks()).getTraversedNodes();
+        operators.forEach(o -> sw.append(o.toString()));
+
+        System.out.println(sw.toString());
+    }
+
+    public static void print(String header, RelNode relTree) {
+        StringWriter sw = new StringWriter();
+
+        sw.append(header).append(":").append("\n");
+
+        RelWriterImpl relWriter = new RelWriterImpl(new PrintWriter(sw), SqlExplainLevel.ALL_ATTRIBUTES, true);
+
+        relTree.explain(relWriter);
+
+        System.out.println(sw.toString());
+    }
+
+    public static void printRecord(Record record) {
+        System.out.println(record.toString());
+    }
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -1,0 +1,122 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.context;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.tools.RuleSet;
+import org.apache.calcite.tools.RuleSets;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+import org.apache.wayang.api.sql.calcite.optimizer.Optimizer;
+import org.apache.wayang.api.sql.calcite.rules.WayangRules;
+import org.apache.wayang.api.sql.calcite.schema.SchemaUtils;
+import org.apache.wayang.api.sql.calcite.utils.PrintUtils;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.LocalCallbackSink;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.WayangContext;
+import org.apache.wayang.core.api.configuration.KeyValueProvider;
+import org.apache.wayang.core.api.configuration.MapBasedKeyValueProvider;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.apache.wayang.java.Java;
+import org.apache.wayang.postgres.Postgres;
+import org.apache.wayang.spark.Spark;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SqlContext {
+
+    private static final AtomicInteger jobId = new AtomicInteger(0);
+
+    private final Configuration configuration;
+
+    private final WayangContext wayangContext;
+
+    private final CalciteSchema calciteSchema;
+
+    public SqlContext() throws SQLException {
+        this(new Configuration());
+    }
+
+    public SqlContext(Configuration configuration) throws SQLException {
+        this.configuration = configuration.fork(String.format("SqlContext(%s)", configuration.getName()));
+
+        wayangContext = new WayangContext(configuration)
+                .withPlugin(Java.basicPlugin())
+                .withPlugin(Spark.basicPlugin())
+                .withPlugin(Postgres.plugin());
+
+        /** hard coded for now **/
+//        calciteSchema = SchemaUtils.getPostgresSchema(configuration);
+        calciteSchema = SchemaUtils.getFileSchema(configuration);
+
+    }
+
+    public Collection<Record> executeSql(String sql) throws Exception {
+
+        Properties configProperties = Optimizer.ConfigProperties.getDefaults();
+        RelDataTypeFactory relDataTypeFactory = new JavaTypeFactoryImpl();
+
+        Optimizer optimizer = Optimizer.create(calciteSchema, configProperties,
+                relDataTypeFactory);
+
+        SqlNode sqlNode = optimizer.parseSql(sql);
+        SqlNode validatedSqlNode = optimizer.validate(sqlNode);
+        RelNode relNode = optimizer.convert(validatedSqlNode);
+
+        PrintUtils.print("After pasrsing sql query", relNode);
+
+
+        RuleSet rules = RuleSets.ofList(
+                WayangRules.WAYANG_TABLESCAN_RULE,
+                WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
+                WayangRules.WAYANG_PROJECT_RULE,
+                WayangRules.WAYANG_FILTER_RULE
+        );
+        RelNode wayangRel = optimizer.optimize(
+                relNode,
+                relNode.getTraitSet().plus(WayangConvention.INSTANCE),
+                rules
+        );
+
+        PrintUtils.print("After translating logical intermediate plan", wayangRel);
+
+
+        Collection<Record> collector = new ArrayList<>();
+        WayangPlan wayangPlan = optimizer.convert(wayangRel, collector);
+        wayangContext.execute(getJobName(), wayangPlan);
+
+        return collector;
+    }
+
+    private static String getJobName() {
+        return "SQL["+jobId.incrementAndGet()+"]";
+    }
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.context;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/CsvRowConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/CsvRowConverter.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.sources.fs;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/CsvRowConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/CsvRowConverter.java
@@ -1,0 +1,170 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.sources.fs;
+
+import au.com.bytecode.opencsv.CSVParser;
+import org.apache.calcite.avatica.util.DateTimeUtils;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.commons.lang3.time.FastDateFormat;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Based on Calcite's CSV enumerator.
+ * TODO: handle different variants
+ *
+ */
+public class CsvRowConverter {
+
+
+    private static final CSVParser parser;
+
+    private static final FastDateFormat TIME_FORMAT_DATE;
+    private static final FastDateFormat TIME_FORMAT_TIME;
+    private static final FastDateFormat TIME_FORMAT_TIMESTAMP;
+
+    static {
+        final TimeZone gmt = TimeZone.getTimeZone("GMT");
+        TIME_FORMAT_DATE = FastDateFormat.getInstance("yyyy-MM-dd", gmt);
+        TIME_FORMAT_TIME = FastDateFormat.getInstance("HH:mm:ss", gmt);
+        TIME_FORMAT_TIMESTAMP = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss", gmt);
+
+        parser = new CSVParser();
+    }
+
+
+
+
+
+    public static Object convert(RelDataType fieldType, String string) {
+        if (fieldType == null || string == null) {
+            return string;
+        }
+        switch (fieldType.getSqlTypeName()) {
+            case BOOLEAN:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Boolean.parseBoolean(string);
+            case TINYINT:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Byte.parseByte(string);
+            case SMALLINT:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Short.parseShort(string);
+            case INTEGER:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Integer.parseInt(string);
+            case BIGINT:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Long.parseLong(string);
+            case FLOAT:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Float.parseFloat(string);
+            case DOUBLE:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return Double.parseDouble(string);
+            case DECIMAL:
+                if (string.length() == 0) {
+                    return null;
+                }
+                return parseDecimal(fieldType.getPrecision(), fieldType.getScale(), string);
+            case DATE:
+                if (string.length() == 0) {
+                    return null;
+                }
+                try {
+                    Date date = TIME_FORMAT_DATE.parse(string);
+                    return (int) (date.getTime() / DateTimeUtils.MILLIS_PER_DAY);
+                } catch (ParseException e) {
+                    return null;
+                }
+            case TIME:
+                if (string.length() == 0) {
+                    return null;
+                }
+                try {
+                    Date date = TIME_FORMAT_TIME.parse(string);
+                    return (int) date.getTime();
+                } catch (ParseException e) {
+                    return null;
+                }
+            case TIMESTAMP:
+                if (string.length() == 0) {
+                    return null;
+                }
+                try {
+                    Date date = TIME_FORMAT_TIMESTAMP.parse(string);
+                    return date.getTime();
+                } catch (ParseException e) {
+                    return null;
+                }
+            case VARCHAR:
+            default:
+                return string;
+        }
+    }
+
+    private static BigDecimal parseDecimal(int precision, int scale, String string) {
+        BigDecimal result = new BigDecimal(string);
+        // If the parsed value has more fractional digits than the specified scale, round ties away
+        // from 0.
+        if (result.scale() > scale) {
+            //TODO: enable logging
+            /*LOGGER.warn(
+                    "Decimal value {} exceeds declared scale ({}). Performing rounding to keep the "
+                            + "first {} fractional digits.",
+                    result, scale, scale);*/
+            result = result.setScale(scale, RoundingMode.HALF_UP);
+        }
+        // Throws an exception if the parsed value has more digits to the left of the decimal point
+        // than the specified value.
+        if (result.precision() - result.scale() > precision - scale) {
+            throw new IllegalArgumentException(String
+                    .format(Locale.ROOT, "Decimal value %s exceeds declared precision (%d) and scale (%d).",
+                            result, precision, scale));
+        }
+        return result;
+    }
+
+
+    public static String[] parseLine(String s) throws IOException {
+        return parser.parseLine(s);
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql.sources.fs;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
@@ -17,10 +17,7 @@
 
 package org.apache.wayang.api.sql.sources.fs;
 
-import org.apache.calcite.adapter.file.CsvEnumerator;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.runtime.CalciteException;
-import org.apache.calcite.util.ImmutableIntList;
 import org.apache.commons.io.IOUtils;
 import org.apache.wayang.basic.channels.FileChannel;
 import org.apache.wayang.basic.data.Record;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/sources/fs/JavaCSVTableSource.java
@@ -1,0 +1,207 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql.sources.fs;
+
+import org.apache.calcite.adapter.file.CsvEnumerator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.CalciteException;
+import org.apache.calcite.util.ImmutableIntList;
+import org.apache.commons.io.IOUtils;
+import org.apache.wayang.basic.channels.FileChannel;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.core.api.exception.WayangException;
+import org.apache.wayang.core.optimizer.OptimizationContext;
+import org.apache.wayang.core.plan.wayangplan.ExecutionOperator;
+import org.apache.wayang.core.plan.wayangplan.UnarySource;
+import org.apache.wayang.core.platform.ChannelDescriptor;
+import org.apache.wayang.core.platform.ChannelInstance;
+import org.apache.wayang.core.platform.lineage.ExecutionLineageNode;
+import org.apache.wayang.core.types.DataSetType;
+import org.apache.wayang.core.util.Tuple;
+import org.apache.wayang.core.util.fs.FileSystem;
+import org.apache.wayang.core.util.fs.FileSystems;
+import org.apache.wayang.core.util.fs.FileUtils;
+import org.apache.wayang.java.channels.StreamChannel;
+import org.apache.wayang.java.execution.JavaExecutor;
+import org.apache.wayang.java.operators.JavaExecutionOperator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class JavaCSVTableSource<T> extends UnarySource<T> implements JavaExecutionOperator {
+
+
+    private final String sourcePath;
+
+    private final List<RelDataType> fieldTypes;
+
+    // TODO: incorporate fields later for projectable table scans
+    // private final ImmutableIntList fields;
+
+    public JavaCSVTableSource(String sourcePath, DataSetType type, List<RelDataType> fieldTypes) {
+        super(type);
+        this.sourcePath = sourcePath;
+        this.fieldTypes = fieldTypes;
+    }
+
+    /*public JavaCSVTableSource(DataSetType<T> type) {
+        this(null, type);
+    }*/
+
+    @Override
+    public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
+            ChannelInstance[] inputs,
+            ChannelInstance[] outputs,
+            JavaExecutor javaExecutor,
+            OptimizationContext.OperatorContext operatorContext) {
+        assert outputs.length == this.getNumOutputs();
+
+        final String path;
+        if (this.sourcePath == null) {
+            final FileChannel.Instance input = (FileChannel.Instance) inputs[0];
+            path = input.getSinglePath();
+        } else {
+            assert inputs.length == 0;
+            path = this.sourcePath;
+        }
+        final String actualInputPath = FileSystems.findActualSingleInputPath(path);
+        Stream<T> stream = this.createStream(actualInputPath);
+        ((StreamChannel.Instance) outputs[0]).accept(stream);
+
+        return ExecutionOperator.modelLazyExecution(inputs, outputs, operatorContext);
+    }
+
+    private Stream<T> createStream(String actualInputPath) {
+        Function<String, T> parser = this::parseLine;
+        return streamLines(actualInputPath).map(parser);
+    }
+
+    private T parseLine(String s) {
+        Class typeClass = this.getType().getDataUnitType().getTypeClass();
+        assert typeClass == Record.class;
+        try {
+            String[] tokens = CsvRowConverter.parseLine(s);
+
+            if (tokens.length != fieldTypes.size()) {
+                throw new IllegalStateException(String.format("Error while parsing CSV file %s at line %s", sourcePath, s));
+            }
+            final Object[] objects = new Object[tokens.length];
+            for (int i = 0; i < tokens.length; i++) {
+                objects[i] = CsvRowConverter.convert(fieldTypes.get(i), tokens[i]);
+            }
+            return (T) new Record(objects);
+        } catch (IOException e) {
+            System.out.println(e.getMessage());
+        }
+        throw new IllegalStateException(String.format("Error while parsing CSV file %s at line %s", sourcePath, s));
+    }
+
+
+
+
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        return Collections.singletonList(FileChannel.HDFS_TSV_DESCRIPTOR);
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        assert index <= this.getNumOutputs() || (index == 0 && this.getNumOutputs() == 0);
+        return Collections.singletonList(StreamChannel.DESCRIPTOR);
+    }
+
+    /**
+     * Copied from {@link FileUtils} as a quick work around to read CSV file after skipping
+     * header row.
+     *
+     * Creates a {@link Stream} of a lines of the file.
+     *
+     * @param path of the file
+     * @return the {@link Stream}
+     */
+    private static Stream<String> streamLines(String path) {
+        final FileSystem fileSystem = FileSystems.getFileSystem(path).orElseThrow(
+                () -> new IllegalStateException(String.format("No file system found for %s", path))
+        );
+        try {
+            Iterator<String> lineIterator = createLineIterator(fileSystem, path);
+            lineIterator.next(); // skip header row
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(lineIterator, 0), false);
+        } catch (IOException e) {
+            throw new WayangException(String.format("%s failed to read %s.", FileUtils.class, path), e);
+        }
+
+    }
+
+    /**
+     * Creates an {@link Iterator} over the lines of a given {@code path} (that resides in the given {@code fileSystem}).
+     */
+    private static Iterator<String> createLineIterator(FileSystem fileSystem, String path) throws IOException {
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(fileSystem.open(path), "UTF-8"));
+        return new Iterator<String>() {
+
+            String next;
+
+            {
+                this.advance();
+            }
+
+            private void advance() {
+                try {
+                    this.next = reader.readLine();
+                } catch (IOException e) {
+                    this.next = null;
+                    throw new UncheckedIOException(e);
+                } finally {
+                    if (this.next == null) {
+                        IOUtils.closeQuietly(reader);
+                    }
+                }
+            }
+
+            @Override
+            public boolean hasNext() {
+                return this.next != null;
+            }
+
+            @Override
+            public String next() {
+                assert this.hasNext();
+                final String returnValue = this.next;
+                this.advance();
+                return returnValue;
+            }
+        };
+
+    }
+
+
+
+
+
+}

--- a/wayang-api/wayang-api-sql/src/main/resources/log4j.properties
+++ b/wayang-api/wayang-api-sql/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Change rootLogger level to WARN
+log4j.rootLogger=WARN, A1
+# Increase level to DEBUG for RelOptPlanner
+log4j.logger.org.apache.calcite.plan.RelOptPlanner=WARN
+# Increase level to TRACE for HepPlanner
+log4j.logger.org.apache.calcite.plan.hep.HepPlanner=WARN

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql;

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
@@ -1,0 +1,114 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql;
+
+import org.apache.log4j.BasicConfigurator;
+import org.apache.wayang.api.sql.context.SqlContext;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.core.api.Configuration;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class SqlAPI {
+
+
+    public static void exampleFs() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setProperty("wayang.fs.table.url", "/data/Projects/databloom/test-data/orders.csv");
+
+        SqlContext sqlContext = new SqlContext(configuration);
+
+        /*Collection<Record> result = sqlContext.executeSql("Select o_orderkey, o_totalprice from fs.orders where " +
+                "o_totalprice > 100");*/
+
+//        Collection<Record> result = sqlContext.executeSql("Select o_orderkey, o_totalprice from fs.orders");
+
+        Collection<Record> result = sqlContext.executeSql("Select o_orderkey, o_totalprice from fs.orders where " +
+                "o_totalprice > 100000");
+
+
+        printResults(10, result);
+
+    }
+
+
+    public static void examplePostgres() throws Exception {
+
+        Configuration configuration = new Configuration();
+        configuration.setProperty("wayang.postgres.jdbc.url", "jdbc:postgresql://localhost:5432/tpch");
+        configuration.setProperty("wayang.postgres.jdbc.user", "kbeedkar");
+        configuration.setProperty("wayang.postgres.jdbc.password", "password");
+
+        SqlContext sqlContext = new SqlContext(configuration);
+
+        /*Collection<Record> result = sqlContext.executeSql(
+                "select c_name, c_acctbal \n"
+                +" from postgres.customer"s
+        );*/
+
+        Collection<Record> result = sqlContext.executeSql(
+                "select c_custkey, c_name, c_acctbal \n"
+                +"from  postgres.customer \n"
+                +"where c_acctbal > 1000 and c_custkey < 20"
+        );
+
+        /*Collection<Record> result = sqlContext.executeSql(
+                "select c_name, c_acctbal \n"
+                +"from  postgres.customer \n"
+                +"where c_name = 'Customer#000000001'"
+        );*/
+
+        /*Collection<Record> result = sqlContext.executeSql(
+                "select c_name, c_phone, c_acctbal, c_nationkey \n"
+                +"from  postgres.customer \n"
+                +"where c_nationkey = 15"
+        );*/
+
+
+        printResults(10, result);
+    }
+
+
+
+
+
+    public static void main(String... args) throws Exception {
+        BasicConfigurator.configure();
+//        new SqlAPI().examplePostgres();
+        new SqlAPI().exampleFs();
+    }
+
+
+    private static void printResults(int n, Collection<Record> result) {
+        // print up to n records
+        int count = 0;
+        Iterator<Record> iterator = result.iterator();
+        while(iterator.hasNext() && count++ < n) {
+            Record record = iterator.next();
+            System.out.print( " | ");
+            for(int i = 0; i < record.size(); i ++) {
+                System.out.print(record.getField(i).toString() + " | ");
+            }
+            System.out.println("");
+        }
+    }
+}

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlTest.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql;

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlTest.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql;
+
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.LocalCallbackSink;
+import org.apache.wayang.basic.operators.MapOperator;
+import org.apache.wayang.basic.operators.TableSource;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.WayangContext;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.apache.wayang.java.Java;
+import org.apache.wayang.postgres.Postgres;
+import org.apache.wayang.postgres.operators.PostgresTableSource;
+import org.apache.wayang.spark.Spark;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+public class SqlTest {
+
+
+    public static void main(String[] args) {
+        WayangPlan wayangPlan;
+        Configuration configuration = new Configuration();
+        configuration.setProperty("wayang.postgres.jdbc.url", "jdbc:postgresql://localhost:5432/tpch");
+        configuration.setProperty("wayang.postgres.jdbc.user", "kbeedkar");
+        configuration.setProperty("wayang.postgres.jdbc.password", "password");
+
+        WayangContext wayangContext = new WayangContext(configuration)
+                .withPlugin(Java.basicPlugin())
+                .withPlugin(Spark.basicPlugin())
+                .withPlugin(Postgres.plugin());
+
+        Collection<Record> collector = new ArrayList<>();
+
+        TableSource customer = new PostgresTableSource("customer");
+        MapOperator<Record, Record> projection = MapOperator.createProjection(
+                Record.class,
+                Record.class,
+                "c_name");
+
+        /*int[] fields = new int[]{1};
+        MapOperator<Record, Record> projection = new MapOperator(
+                new WayangProjectVisitor.MapFunctionImpl(fields),
+                Record.class,
+                Record.class);*/
+
+        LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
+        customer.connectTo(0,projection,0);
+        projection.connectTo(0,sink,0);
+
+
+        wayangPlan = new WayangPlan(sink);
+
+        wayangContext.execute("PostgreSql test", wayangPlan);
+
+
+        int count = 10;
+        for(Record r : collector) {
+            System.out.println(r.getField(0).toString());
+            if(--count == 0 ) {
+                break;
+            }
+        }
+        System.out.println("Done");
+
+
+
+
+
+
+
+
+    }
+
+
+}
+
+

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -34,7 +34,6 @@ import org.apache.wayang.api.sql.calcite.schema.WayangTableBuilder;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.PlanTraversal;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
-import org.junit.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -43,7 +42,6 @@ import java.util.Collection;
 
 public class SqlToWayangRelTest {
 
-    @Test
     public void test_simple_sql() throws Exception {
         WayangTable customer = WayangTableBuilder.build("customer")
                 .addField("id", SqlTypeName.INTEGER)

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -1,21 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.wayang.api.sql;

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.wayang.api.sql;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.externalize.RelWriterImpl;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RuleSet;
+import org.apache.calcite.tools.RuleSets;
+import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
+import org.apache.wayang.api.sql.calcite.optimizer.Optimizer;
+import org.apache.wayang.api.sql.calcite.rules.WayangRules;
+import org.apache.wayang.api.sql.calcite.schema.WayangSchema;
+import org.apache.wayang.api.sql.calcite.schema.WayangSchemaBuilder;
+import org.apache.wayang.api.sql.calcite.schema.WayangTable;
+import org.apache.wayang.api.sql.calcite.schema.WayangTableBuilder;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.plan.wayangplan.PlanTraversal;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+
+
+public class SqlToWayangRelTest {
+
+    @Test
+    public void test_simple_sql() throws Exception {
+        WayangTable customer = WayangTableBuilder.build("customer")
+                .addField("id", SqlTypeName.INTEGER)
+                .addField("name", SqlTypeName.VARCHAR)
+                .addField("age", SqlTypeName.INTEGER)
+                .withRowCount(100)
+                .build();
+
+        WayangTable orders = WayangTableBuilder.build("orders")
+                .addField("id", SqlTypeName.INTEGER)
+                .addField("cid", SqlTypeName.INTEGER)
+                .addField("price", SqlTypeName.DECIMAL)
+                .addField("quantity", SqlTypeName.INTEGER)
+                .withRowCount(100)
+                .build();
+
+        WayangSchema wayangSchema = WayangSchemaBuilder.build("exSchema")
+                .addTable(customer)
+                .addTable(orders)
+                .build();
+
+        Optimizer optimizer = Optimizer.create(wayangSchema);
+
+//        String sql = "select c.name, c.age from customer c where (c.age < 40 or c.age > 60) and \'alex\' = c.name";
+//        String sql = "select c.age from customer c";
+        String sql = "select c.name, c.age, o.price from customer c join orders o on c.id = o.cid where c.age > 40 " +
+                "and o" +
+                ".price < 100";
+
+
+        SqlNode sqlNode = optimizer.parseSql(sql);
+        SqlNode validatedSqlNode = optimizer.validate(sqlNode);
+        RelNode relNode = optimizer.convert(validatedSqlNode);
+
+        print("After parsing", relNode);
+
+
+        RuleSet rules = RuleSets.ofList(
+                WayangRules.WAYANG_TABLESCAN_RULE,
+                WayangRules.WAYANG_PROJECT_RULE,
+                WayangRules.WAYANG_FILTER_RULE,
+                WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
+                WayangRules.WAYANG_JOIN_RULE
+        );
+
+        RelNode wayangRel = optimizer.optimize(
+                relNode,
+                relNode.getTraitSet().plus(WayangConvention.INSTANCE),
+                rules
+        );
+
+        print("After rel to wayang conversion", wayangRel);
+
+
+        //WayangPlan plan = optimizer.convert(wayangRel);
+
+        //print("After Translating to WayangPlan", plan);
+
+
+
+    }
+
+
+    private void print(String header, WayangPlan plan) {
+        StringWriter sw = new StringWriter();
+        sw.append(header).append(":").append("\n");
+
+        final Collection<Operator> operators = PlanTraversal.upstream().traverse(plan.getSinks()).getTraversedNodes();
+        operators.forEach(o -> sw.append(o.toString()));
+
+        System.out.println(sw.toString());
+    }
+
+    private void print(String header, RelNode relTree) {
+        StringWriter sw = new StringWriter();
+
+        sw.append(header).append(":").append("\n");
+
+        RelWriterImpl relWriter = new RelWriterImpl(new PrintWriter(sw), SqlExplainLevel.ALL_ATTRIBUTES, true);
+
+        relTree.explain(relWriter);
+
+        System.out.println(sw.toString());
+    }
+
+}

--- a/wayang-api/wayang-api-sql/src/test/resources/log4j.properties
+++ b/wayang-api/wayang-api-sql/src/test/resources/log4j.properties
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Change rootLogger level to WARN
+log4j.rootLogger=WARN, A1
+# Increase level to DEBUG for RelOptPlanner
+log4j.logger.org.apache.calcite.plan.RelOptPlanner=WARN
+# Increase level to TRACE for HepPlanner
+log4j.logger.org.apache.calcite.plan.hep.HepPlanner=WARN


### PR DESCRIPTION
- This initial version of the SQL API supports simple Select-Project Queries over Databases and Java Platform.
- SQL support is based on Apache Calcite

