### PR TITLE
Benchmarks detailed instructions

### DIFF
--- a/bin/wayang-submit
+++ b/bin/wayang-submit
@@ -113,5 +113,12 @@ if [ -n "${OTHER_FLAGS}" ]; then
 	FLAGS="${FLAGS} ${OTHER_FLAGS}"
 fi
 
-eval "$RUNNER $FLAGS -cp "${WAYANG_CLASSPATH}" $CLASS ${@:2}"
+# Wrap args in quotes to be able to execute args with parenthesis, spaces, etc
+ARGS=""
+for arg in $(echo ${@:2})
+do
+  ARGS="$ARGS \"${arg}\""
+done
+
+eval "$RUNNER $FLAGS -cp "${WAYANG_CLASSPATH}" $CLASS ${ARGS}"
 

--- a/wayang-benchmark/README.md
+++ b/wayang-benchmark/README.md
@@ -4,7 +4,25 @@ This repository provides example applications and further benchmarking tools to 
 
 Below we provide detailed information on our various benchmark components, including running instructions. For the configuration of Apache Wayang (incubating) itself, please consult the [Apache Wayang (incubating) repository](https://github.com/apache/incubator-wayang) or feel free to reach out on [dev@wayang.apache.org](mailto:dev@wayang.apache.org).
 
+
 ## Apache Wayang (incubating) Example Applications
+
+### Launching the main class
+
+To run any of the following example applications, use this format:
+
+```shell
+<main class> exp(<ID>[,tags=<tag>,...][,conf=<key>:<value>,...]) <plugin>(,<plugin>)* <arg1> <arg2> ...
+```
+
+Replace `<arg1> <arg2>, ...` with the application-specific parameters that you want to use.
+
+For example, to run the `org.apache.wayang.apps.wordcount.WordCountScala` class with the `exp(123)` experiment descriptor and the `java` plugin, use:
+```bash
+./bin/wayang-submit org.apache.wayang.apps.wordcount.WordCountScala exp\(123\) java file://$(pwd)/README.md
+```
+
+**Note** that the `file://$(pwd)/example_file.txt` format should be used for dealing with files.
 
 ### WordCount
 


### PR DESCRIPTION
Added more detailed instructions on how to run the benchmark programs and tweaked the wayang-submit script by wrapping arguments in quotes to avoid problems with spaces, parentheses, etc