### PR TITLE
SQL API extensions to support joins

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
@@ -18,7 +18,18 @@
 
 package org.apache.wayang.api.sql.calcite.converter;
 
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.operators.JoinOperator;
+import org.apache.wayang.basic.operators.MapOperator;
+import org.apache.wayang.core.function.FunctionDescriptor;
+import org.apache.wayang.core.function.TransformationDescriptor;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 
 public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
@@ -30,8 +41,101 @@ public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
     @Override
     Operator visit(WayangJoin wayangRelNode) {
 
+        Operator leftChildOperator = wayangRelConverter.convert(wayangRelNode.getInput(0));
+        Operator rightChildOperator = wayangRelConverter.convert(wayangRelNode.getInput(1));
+
+        // Get the join condition. Only supports equality join
+        RexNode condition = wayangRelNode.getCondition();
+        if(!condition.isA(SqlKind.EQUALS)) {
+            new UnsupportedOperationException("Only equality joins supported");
+        }
+
+        //offset of the index in the right child
+        int offset = wayangRelNode.getInput(0).getRowType().getFieldCount();
+
+        // get the offset of keys in left and right records
+        int leftKeyIndex = condition.accept(new keyIndex(false, Child.LEFT));
+        int rightKeyIndex = condition.accept(new keyIndex(false, Child.RIGHT)) - offset;
 
 
-        return null;
+        JoinOperator<Record, Record, Object>  joinOperator = new JoinOperator<>(
+                new TransformationDescriptor<>(new KeyUdf(leftKeyIndex), Record.class, Object.class),
+                new TransformationDescriptor<>(new KeyUdf(rightKeyIndex), Record.class, Object.class)
+        );
+
+
+        leftChildOperator.connectTo(0,joinOperator,0);
+        rightChildOperator.connectTo(0,joinOperator,1);
+
+        // The join outputs a Tuple2<Record, Record>, lets translate that to a Record
+        MapOperator<Tuple2, Record> mapOperator = new MapOperator(
+                new MapFunctionImpl(),
+                Tuple2.class,
+                Record.class);
+        joinOperator.connectTo(0,mapOperator,0);
+        return mapOperator;
+
+    }
+
+    private class keyIndex extends RexVisitorImpl<Integer> {
+
+        Child child;
+        protected keyIndex(boolean deep, Child child) {
+            super(deep);
+            this.child = child;
+        }
+
+        @Override
+        public Integer visitCall(RexCall call) {
+            RexNode operand = call.getOperands().get(child.ordinal());
+            if(!(operand instanceof RexInputRef)) {
+                new UnsupportedOperationException("unsupported operation");
+            }
+            RexInputRef rexInputRef = (RexInputRef)operand;
+            return rexInputRef.getIndex();
+        }
+    }
+
+    private class KeyUdf implements FunctionDescriptor.SerializableFunction<Record, Object> {
+
+        int index;
+        public KeyUdf(int index) {
+        this.index = index;
+        }
+
+        @Override
+        public Object apply(Record record) {
+            return record.getField(index);
+        }
+    }
+
+   private class MapFunctionImpl implements
+            FunctionDescriptor.SerializableFunction<Tuple2<Record,Record>, Record> {
+        public MapFunctionImpl() {
+            super();
+        }
+
+        @Override
+        public Record apply(Tuple2<Record, Record> tuple2) {
+            Record r1 = tuple2.getField0();
+            Record r2 = tuple2.getField1();
+
+            int totalSize = r1.size()+ r2.size();
+
+            Object[] objects = new Object[totalSize];
+            int i = 0;
+            for(;i < r1.size(); i++) {
+                objects[i] = r1.getField(i);
+            }
+            for(int j = 0 ; j < r2.size(); j++, i++) {
+                objects[i] = r2.getField(j);
+            }
+            return new Record(objects);
+        }
+    }
+
+    // Helpers
+    private enum Child {
+        LEFT, RIGHT
     }
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
@@ -21,6 +21,7 @@ package org.apache.wayang.api.sql.calcite.converter;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.wayang.api.sql.calcite.rel.WayangFilter;
+import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
 import org.apache.wayang.api.sql.calcite.rel.WayangProject;
 import org.apache.wayang.api.sql.calcite.rel.WayangTableScan;
 import org.apache.wayang.core.plan.wayangplan.Operator;
@@ -34,6 +35,8 @@ public class WayangRelConverter {
             return new WayangProjectVisitor(this).visit((WayangProject) node);
         } else if (node instanceof WayangFilter) {
             return new WayangFilterVisitor(this).visit((WayangFilter) node);
+        } else if (node instanceof WayangJoin) {
+            return new WayangJoinVisitor(this).visit((WayangJoin) node);
         }
         throw new IllegalStateException("Operator translation not supported yet");
     }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -86,7 +86,8 @@ public class SqlContext {
                 WayangRules.WAYANG_TABLESCAN_RULE,
                 WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
                 WayangRules.WAYANG_PROJECT_RULE,
-                WayangRules.WAYANG_FILTER_RULE
+                WayangRules.WAYANG_FILTER_RULE,
+                WayangRules.WAYANG_JOIN_RULE
         );
         RelNode wayangRel = optimizer.optimize(
                 relNode,

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlAPI.java
@@ -108,6 +108,28 @@ public class SqlAPI {
     }
 
 
+    public static void exampleJoinWithPostgres() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setProperty("wayang.postgres.jdbc.url", "jdbc:postgresql://localhost:5432/dvdrental");
+        configuration.setProperty("wayang.postgres.jdbc.user", "user");
+        configuration.setProperty("wayang.postgres.jdbc.password", "password");
+
+        String calciteModel = Resources.toString(
+                SqlAPI.class.getResource("/model.json"),
+                Charset.defaultCharset());
+        configuration.setProperty("wayang.calcite.model",calciteModel);
+
+        SqlContext sqlContext = new SqlContext(configuration);
+
+
+        Collection<Record> result = sqlContext.executeSql(
+                "select actor_id, category_id from postgres.film_actor a inner join postgres.film_category c on a.film_id = c.film_id"
+        );
+
+        printResults(10, result);
+    }
+
+
 
 
 
@@ -115,7 +137,8 @@ public class SqlAPI {
         BasicConfigurator.configure();
 //        new SqlAPI().examplePostgres();
 //        new SqlAPI().exampleFs();
-        new SqlAPI().exampleWithPostgres();
+//        new SqlAPI().exampleWithPostgres();
+        new SqlAPI().exampleJoinWithPostgres();
     }
 
 


### PR DESCRIPTION
This PR makes extends the SQL API to also handle joins.

- Algebraic Joins are transpiled to Wayang Join Operator
- Since the JoinOperator outputs a Tuple2<Record, Record>, the join is fused with a MapOperator to output <Record>
- This is required to have downstream operations on joins such as projections/aggregations.

With this PR merged, Wayang can now support simple and basic SPJ queries for decoupled JDBC sources and CSV data sources.