### PR TITLE
Revert "Bump calcite-core from 1.29.0 to 1.32.0 in /wayang-api/wayang-api-sql"

### DIFF
--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.32.0</version>
+            <version>1.29.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>


### PR DESCRIPTION
Reverts apache/incubator-wayang#302 to avoid building errors