### PR TITLE
add EPL and PD license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1280,7 +1280,7 @@
                         <licenseMerge>HSQLDB | HSQLDB License, a BSD open source license</licenseMerge>
                     </licenseMerges>
                     <includedLicenses>
-                        ASF 2.0 | BSD 2-claus | BSD 3-claus | MIT | CC0 | HSQLDB | PostgreSQL
+                        ASF 2.0 | BSD 2-claus | BSD 3-claus | MIT | CC0 | HSQLDB | PostgreSQL | EPL 2.0 | EPL 1.0 | Public Domain | iCal4j
                     </includedLicenses>
                     <failOnBlacklist>true</failOnBlacklist>
                     <excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -1278,9 +1278,10 @@
                         <licenseMerge>MIT | MIT License | The MIT License </licenseMerge>
                         <licenseMerge>BSD 2-claus | BSD 2-Clause License | BSD 2-Clause | BSD-2-Clause</licenseMerge>
                         <licenseMerge>HSQLDB | HSQLDB License, a BSD open source license</licenseMerge>
+                        <licenseMerge>Eclipse | EPL 2.0 |  EPL 1.0 | Eclipse Public License, Version 2.0 | Eclipse Distribution License - v 1.0</licenseMerge>
                     </licenseMerges>
                     <includedLicenses>
-                        ASF 2.0 | BSD 2-claus | BSD 3-claus | MIT | CC0 | HSQLDB | PostgreSQL | EPL 2.0 | EPL 1.0 | Public Domain | iCal4j
+                        ASF 2.0 | BSD 2-claus | BSD 3-claus | MIT | CC0 | HSQLDB | PostgreSQL | Eclipse | Public Domain | iCal4j - License
                     </includedLicenses>
                     <failOnBlacklist>true</failOnBlacklist>
                     <excludedGroups>


### PR DESCRIPTION
as workaround also iCal4j - not sure if it works. I don't know why not using https://github.com/ical4j/ical4j which is BSD 3