### PR TITLE
Added the following flink operator tests: MaterializedGroupByOperator, SortOperator, UnionAllOperator

### DIFF
--- a/wayang-platforms/wayang-flink/code/main/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperator.java
+++ b/wayang-platforms/wayang-flink/code/main/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperator.java
@@ -90,7 +90,8 @@ public class FlinkMaterializedGroupByOperator<Type, KeyType>
                             iterable.forEach(dataUnitGroup::add);
                             collector.collect(dataUnitGroup);
                         }
-                    );
+                    )
+                    .returns(this.getOutputType().getDataUnitType().getTypeClass());
 
         output.accept(dataSetOutput, flinkExecutor);
 

--- a/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperatorTest.java
+++ b/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.wayang.flink.operators;
 
 import org.apache.wayang.basic.data.Tuple2;

--- a/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperatorTest.java
+++ b/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkMaterializedGroupByOperatorTest.java
@@ -1,0 +1,81 @@
+package org.apache.wayang.flink.operators;
+
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.function.ProjectionDescriptor;
+import org.apache.wayang.core.platform.ChannelInstance;
+import org.apache.wayang.core.types.DataSetType;
+import org.apache.wayang.core.types.DataUnitType;
+import org.apache.wayang.flink.channels.DataSetChannel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Test suite for {@link FlinkMaterializedGroupByOperator}.
+ */
+public class FlinkMaterializedGroupByOperatorTest extends FlinkOperatorTestBase {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testExecution() throws Exception {
+        // Prepare test data.
+        AtomicInteger counter = new AtomicInteger(0);
+        DataSetChannel.Instance input = this.createDataSetChannelInstance(Arrays.stream("abcaba".split(""))
+                .map(string -> new Tuple2<>(string, counter.getAndIncrement()))
+                .collect(Collectors.toList()));
+        DataSetChannel.Instance output = this.createDataSetChannelInstance();
+
+        // Build the reduce operator.
+        FlinkMaterializedGroupByOperator<Tuple2<String, Integer>, String> collocateByOperator =
+                new FlinkMaterializedGroupByOperator<>(
+                        new ProjectionDescriptor<>(
+                                DataUnitType.createBasicUnchecked(Tuple2.class),
+                                DataUnitType.createBasicUnchecked(String.class),
+                                "field0"
+                        ),
+                        DataSetType.createDefaultUnchecked(Tuple2.class),
+                        DataSetType.createGroupedUnchecked(String.class)
+                );
+
+        // Set up the ChannelInstances.
+        final ChannelInstance[] inputs = new ChannelInstance[]{input};
+        final ChannelInstance[] outputs = new ChannelInstance[]{output};
+
+        // Execute.
+        try {
+            this.evaluate(collocateByOperator, inputs, outputs);
+        }
+        catch (Exception e){
+            e.printStackTrace();
+            Assert.fail();
+        }
+
+        // Verify the outcome.
+        final List<Iterable<Tuple2<String, Integer>>> originalResult =
+                output.<Iterable<Tuple2<String, Integer>>>provideDataSet().collect();
+        Set<List<Tuple2<String, Integer>>> result = originalResult.stream()
+                .map(this::toList)
+                .collect(Collectors.toSet());
+
+        final List[] expectedResults = {
+                Arrays.asList(new Tuple2<>("a", 0), new Tuple2<>("a", 3), new Tuple2<>("a", 5)),
+                Arrays.asList(new Tuple2<>("b", 1), new Tuple2<>("b", 4)),
+                Arrays.asList(new Tuple2<>("c", 2))
+        };
+        Arrays.stream(expectedResults)
+                .forEach(expected -> Assert.assertTrue("Not contained: " + expected, result.contains(expected)));
+        Assert.assertEquals(expectedResults.length, result.size());
+
+    }
+
+    private <T> List<T> toList(Iterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList());
+    }
+
+}

--- a/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkSortOperatorTest.java
+++ b/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkSortOperatorTest.java
@@ -1,0 +1,46 @@
+package org.apache.wayang.flink.operators;
+
+import org.apache.wayang.core.function.TransformationDescriptor;
+import org.apache.wayang.core.platform.ChannelInstance;
+import org.apache.wayang.core.types.DataSetType;
+import org.apache.wayang.flink.channels.DataSetChannel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test suite for {@link FlinkSortOperator}.
+ */
+public class FlinkSortOperatorTest extends FlinkOperatorTestBase {
+
+    @Test
+    public void testExecution() throws Exception {
+        // Prepare test data.
+        DataSetChannel.Instance input = this.createDataSetChannelInstance(Arrays.asList(6, 0, 1, 1, 5, 2));
+        DataSetChannel.Instance output = this.createDataSetChannelInstance();
+
+
+        // Build the sort operator.
+        FlinkSortOperator<Integer, Integer> sortOperator =
+                new FlinkSortOperator<>(
+                        new TransformationDescriptor(r->r, Integer.class, Integer.class),
+                        DataSetType.createDefaultUnchecked(Integer.class)
+                );
+
+        // Set up the ChannelInstances.
+        final ChannelInstance[] inputs = new ChannelInstance[]{input};
+        final ChannelInstance[] outputs = new ChannelInstance[]{output};
+
+        // Execute.
+        this.evaluate(sortOperator, inputs, outputs);
+
+        // Verify the outcome.
+        final List<Integer> result = output.<Integer>provideDataSet().collect();
+        Assert.assertEquals(6, result.size());
+        Assert.assertEquals(Arrays.asList(0, 1, 1, 2, 5, 6), result);
+
+    }
+
+}

--- a/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkSortOperatorTest.java
+++ b/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkSortOperatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.wayang.flink.operators;
 
 import org.apache.wayang.core.function.TransformationDescriptor;

--- a/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkUnionAllOperatorTest.java
+++ b/wayang-platforms/wayang-flink/code/test/java/org/apache/wayang/flink/operators/FlinkUnionAllOperatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.flink.operators;
+
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.core.platform.ChannelInstance;
+import org.apache.wayang.core.types.DataSetType;
+import org.apache.wayang.flink.channels.DataSetChannel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test suite for {@link FlinkUnionAllOperator}.
+ */
+public class FlinkUnionAllOperatorTest extends FlinkOperatorTestBase {
+
+    @Test
+    public void testExecution() throws Exception {
+        // Prepare test data.
+        DataSetChannel.Instance input0 = this.createDataSetChannelInstance(Arrays.asList(6, 0, 1, 1, 5, 2));
+        DataSetChannel.Instance input1 = this.createDataSetChannelInstance(Arrays.asList(1, 1, 9));
+        DataSetChannel.Instance output = this.createDataSetChannelInstance();
+
+        // Build the UnionAll operator.
+        FlinkUnionAllOperator<Integer> unionAllOperator =
+                new FlinkUnionAllOperator<>(
+                        DataSetType.createDefaultUnchecked(Integer.class)
+                );
+
+        // Set up the ChannelInstances.
+        final ChannelInstance[] inputs = new ChannelInstance[]{input0, input1};
+        final ChannelInstance[] outputs = new ChannelInstance[]{output};
+
+        // Execute.
+        this.evaluate(unionAllOperator, inputs, outputs);
+
+        // Verify the outcome.
+        final List<Integer> result = output.<Integer>provideDataSet().collect();
+        // final List<Integer> result = ((DataSetChannel.Instance) outputs[0]).<Integer>provideDataSet().collect();
+        Assert.assertEquals(9, result.size());
+        Assert.assertEquals(Arrays.asList(6, 0, 1, 1, 5, 2, 1, 1, 9), result);
+    }
+}


### PR DESCRIPTION
Note that the FlinkMaterializedGroupByOperatorTest, although it succeeds, it produces the following messages:

[ERROR] WARNING: An illegal reflective access operation has occurred
[ERROR] WARNING: Illegal reflective access by com.esotericsoftware.kryo.util.UnsafeUtil (file:/C:/Users/Mike/.m2/repository/com/esotericsoftware/kryo/kryo/2.24.0/kryo-2.24.0.jar) to constructor java.nio.DirectByteBuffer(long,int,java.lang.Object)
[ERROR] WARNING: Please consider reporting this to the maintainers of com.esotericsoftware.kryo.util.UnsafeUtil
[ERROR] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[ERROR] WARNING: All illegal access operations will be denied in a future release

These are also produced by its respective Spark test, SparkMaterializedGroupByOperatorTest.