### PR TITLE
update calcite-linq4j version in api-sql pom to match calcite-core version

### DIFF
--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-linq4j</artifactId>
-            <version>1.29.0</version>
+            <version>1.32.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>


### PR DESCRIPTION
After the calcite-core version was upgraded to 1.32.0, the cross-platform example was not running. We got the following error related to the calcite-linq4j dependency: 

Caused by: java.lang.NoSuchMethodException: org.apache.calcite.linq4j.EnumerableDefaults.repeatUnion(org.apache.calcite.linq4j.Enumerable,org.apache.calcite.linq4j.Enumerable,int,boolean,org.apache.calcite.linq4j.function.EqualityComparer,org.apache.calcite.linq4j.function.Function0)
	at java.base/java.lang.Class.getMethod(Class.java:2321)
	at org.apache.calcite.linq4j.tree.Types.lookupMethod(Types.java:309)

We tested on our fork and it works, when we upgraded the calcite-linq4j to 1.32.0 (in the wayang-api-sql pom file) as well, so the two dependency versions match. 