### PR TITLE
Add explain command to display debug information for inflated wayang plans and execution plans

### DIFF
--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
@@ -20,6 +20,7 @@ package org.apache.wayang.core.api;
 
 import org.apache.wayang.commons.util.profiledb.model.Experiment;
 import org.apache.wayang.commons.util.profiledb.model.Subject;
+import org.apache.commons.lang.StringUtils;
 import org.apache.wayang.core.monitor.Monitor;
 import org.apache.wayang.core.optimizer.cardinality.CardinalityEstimator;
 import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
@@ -28,6 +29,7 @@ import org.apache.wayang.core.plugin.Plugin;
 import org.apache.wayang.core.profiling.CardinalityRepository;
 import org.apache.wayang.core.util.ExplainUtils;
 import org.apache.wayang.core.util.ReflectionUtils;
+import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -138,8 +140,36 @@ public class WayangContext {
         Job job = this.createJob(null, null, wayangPlan, udfJars);
         ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
 
-        ExplainUtils.parsePlan(wayangPlan);
-        ExplainUtils.parsePlan(executionPlan);
+        ExplainUtils.parsePlan(wayangPlan, (op, level) -> {
+            if (op instanceof OperatorAlternative) {
+                OperatorAlternative alts = (OperatorAlternative) op;
+                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
+            } else {
+                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + op);
+            }
+        });
+        System.out.println();
+        ExplainUtils.parsePlan(executionPlan, (task, level) -> {
+            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + task.getOperator());
+        });
+    }
+
+    public void explain(WayangPlan wayangPlan, boolean toJson, String... udfJars) {
+        Job job = this.createJob(null, null, wayangPlan, udfJars);
+        ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
+
+        ExplainUtils.parsePlan(wayangPlan, (op, level) -> {
+            if (op instanceof OperatorAlternative) {
+                OperatorAlternative alts = (OperatorAlternative) op;
+                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
+            } else {
+                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + op);
+            }
+        });
+
+        ExplainUtils.parsePlan(executionPlan, (task, level) -> {
+            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + task.getOperator());
+        });
     }
 
 

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
@@ -20,7 +20,6 @@ package org.apache.wayang.core.api;
 
 import org.apache.wayang.commons.util.profiledb.model.Experiment;
 import org.apache.wayang.commons.util.profiledb.model.Subject;
-import org.apache.commons.lang.StringUtils;
 import org.apache.wayang.core.monitor.Monitor;
 import org.apache.wayang.core.optimizer.cardinality.CardinalityEstimator;
 import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
@@ -140,36 +139,17 @@ public class WayangContext {
         Job job = this.createJob(null, null, wayangPlan, udfJars);
         ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
 
-        ExplainUtils.parsePlan(wayangPlan, (op, level) -> {
-            if (op instanceof OperatorAlternative) {
-                OperatorAlternative alts = (OperatorAlternative) op;
-                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
-            } else {
-                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + op);
-            }
-        });
+        ExplainUtils.parsePlan(wayangPlan, false);
         System.out.println();
-        ExplainUtils.parsePlan(executionPlan, (task, level) -> {
-            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + task.getOperator());
-        });
+        ExplainUtils.parsePlan(executionPlan, false);
     }
 
     public void explain(WayangPlan wayangPlan, boolean toJson, String... udfJars) {
         Job job = this.createJob(null, null, wayangPlan, udfJars);
         ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
 
-        ExplainUtils.parsePlan(wayangPlan, (op, level) -> {
-            if (op instanceof OperatorAlternative) {
-                OperatorAlternative alts = (OperatorAlternative) op;
-                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
-            } else {
-                System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + op);
-            }
-        });
-
-        ExplainUtils.parsePlan(executionPlan, (task, level) -> {
-            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + task.getOperator());
-        });
+        ExplainUtils.parsePlan(wayangPlan, true);
+        ExplainUtils.parsePlan(executionPlan, true);
     }
 
 

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
@@ -28,7 +28,6 @@ import org.apache.wayang.core.plugin.Plugin;
 import org.apache.wayang.core.profiling.CardinalityRepository;
 import org.apache.wayang.core.util.ExplainUtils;
 import org.apache.wayang.core.util.ReflectionUtils;
-import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -148,8 +147,14 @@ public class WayangContext {
         Job job = this.createJob(null, null, wayangPlan, udfJars);
         ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
 
-        ExplainUtils.parsePlan(wayangPlan, true);
-        ExplainUtils.parsePlan(executionPlan, true);
+        ExplainUtils.write(
+            ExplainUtils.parsePlan(wayangPlan, true),
+            this.configuration.getStringProperty("wayang.core.explain.logical.file")
+        );
+        ExplainUtils.write(
+            ExplainUtils.parsePlan(executionPlan, true),
+            this.configuration.getStringProperty("wayang.core.explain.execution.file")
+        );
     }
 
 

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
@@ -26,6 +26,7 @@ import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 import org.apache.wayang.core.plugin.Plugin;
 import org.apache.wayang.core.profiling.CardinalityRepository;
+import org.apache.wayang.core.util.ExplainUtils;
 import org.apache.wayang.core.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -131,6 +132,14 @@ public class WayangContext {
      */
     public void execute(String jobName, WayangPlan wayangPlan, Experiment experiment, String... udfJars) {
         this.createJob(jobName, wayangPlan, experiment, udfJars).execute();
+    }
+
+    public void explain(WayangPlan wayangPlan, String... udfJars) {
+        Job job = this.createJob(null, null, wayangPlan, udfJars);
+        ExecutionPlan executionPlan = job.buildInitialExecutionPlan();
+
+        ExplainUtils.parsePlan(wayangPlan);
+        ExplainUtils.parsePlan(executionPlan);
     }
 
 

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainTreeNode.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainTreeNode.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.core.util;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.wayang.core.util.JsonSerializable;
+import org.apache.wayang.core.util.json.WayangJsonObj;
+import org.apache.wayang.core.util.json.WayangJsonArray;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
+import org.apache.wayang.core.plan.wayangplan.ExecutionOperator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExplainTreeNode implements JsonSerializable {
+    public Operator operator;
+    public List<ExplainTreeNode> children = new ArrayList<>();
+
+    @Override
+    public WayangJsonObj toJson() {
+        WayangJsonObj result = new WayangJsonObj();
+
+        if (this.operator instanceof OperatorAlternative) {
+            OperatorAlternative alts = (OperatorAlternative) this.operator;
+            result.put(
+                "name",
+                alts.getAlternatives()
+                    .get(0)
+                    .getContainedOperators()
+                    .iterator()
+                    .next()
+                    .getClass()
+                    .getSimpleName()
+            );
+        } else {
+            result.put("name", this.operator.getClass().getSimpleName());
+        }
+
+        if (this.operator instanceof ExecutionOperator) {
+            result.put("platform", ((ExecutionOperator) this.operator).getPlatform().getName());
+        }
+
+        if (!operator.isSource() && !operator.isSink() && operator.getName() != null) {
+            WayangJsonObj attributes = new WayangJsonObj();
+            attributes.put("operation", operator.getName());
+            result.put("attributes", attributes);
+        }
+
+        if (this.children.size() > 0) {
+            final WayangJsonArray jsonChildren = new WayangJsonArray();
+            this.children.stream().forEach(child -> {
+                jsonChildren.put(child.toJson());
+            });
+            result.put("children", jsonChildren);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unused")
+    public static ExplainTreeNode fromJson(WayangJsonObj obj) {
+        return new ExplainTreeNode();
+    }
+}

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
@@ -18,11 +18,13 @@
 
 package org.apache.wayang.core.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
 import org.apache.wayang.core.plan.executionplan.ExecutionTask;
+import org.apache.wayang.core.plan.executionplan.Channel;
 
 import java.util.List;
 import java.util.Set;
@@ -39,65 +41,97 @@ public class ExplainUtils {
 
     public static final String INDENT = "  ";
 
-    public static void parsePlan(WayangPlan plan, BiConsumer<Operator, Integer> func) {
+    public static void parsePlan(WayangPlan plan, boolean upstream) {
         System.out.println("== Wayang Plan ==");
         HashMap<Operator, Collection<Operator>> tree = new HashMap<>();
-        Collection<Operator> sources = plan.collectReachableTopLevelSources();
+        Collection<Operator> roots = plan.collectReachableTopLevelSources();
 
-        for (Operator source : sources) {
-            traverse(source, func, tree, 0);
+        if (upstream) {
+            roots = plan.getSinks();
+        }
+
+        for (Operator root : roots) {
+            traverse(root, upstream, tree, 0);
         }
     }
 
-    public static void parsePlan(ExecutionPlan plan, BiConsumer<ExecutionTask, Integer> func) {
+    public static void parsePlan(ExecutionPlan plan, boolean upstream) {
         System.out.println("== Execution Plan ==");
         HashMap<Operator, Collection<ExecutionTask>> tree = new HashMap<>();
         Set<ExecutionTask> tasks = plan.collectAllTasks();
 
-        Collection<ExecutionTask> sources = tasks.stream()
+        Collection<ExecutionTask> roots;
+
+        if (upstream) {
+            roots = tasks.stream()
+            .filter(task -> task.getOperator().isSink())
+            .collect(Collectors.toList());
+        } else {
+            roots = tasks.stream()
             .filter(task -> task.getOperator().isSource())
             .collect(Collectors.toList());
+        }
 
-        for (ExecutionTask source : sources) {
-            traverse(source, func, tree, 0);
+        for (ExecutionTask root : roots) {
+            traverse(root, upstream, tree, 0);
         }
     }
 
-    private static void traverse(Operator current, BiConsumer<Operator, Integer> func, HashMap<Operator, Collection<Operator>> visited, int level) {
-        func.accept(current, level);
+    private static void traverse(Operator current, boolean upstream, HashMap<Operator, Collection<Operator>> visited, int level) {
+        if (current instanceof OperatorAlternative) {
+            OperatorAlternative alts = (OperatorAlternative) current;
+            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
+        } else {
+            System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + current);
+        }
 
         if (visited.containsKey(current)) {
             return;
         }
 
-        Collection<Operator> outputs = Stream.of(current.getAllOutputs())
-            .flatMap(output -> {
-                return output
-                    .getOccupiedSlots()
-                    .stream()
-                    .map(input -> input.getOwner());
-            })
-            .collect(Collectors.toList());
+        Collection<Operator> children;
 
-        for (Operator output : outputs) {
-            traverse(output, func, visited, level + 1);
+        if (upstream) {
+            children = Stream.of(current.getAllInputs())
+                .filter(input -> input.getOccupant() != null)
+                .map(input -> input.getOccupant().getOwner())
+                .collect(Collectors.toList());
+        } else {
+            children = Stream.of(current.getAllOutputs())
+                .flatMap(output -> {
+                    return output
+                        .getOccupiedSlots()
+                        .stream()
+                        .map(input -> input.getOwner());
+                })
+                .collect(Collectors.toList());
+        }
+
+        for (Operator child : children) {
+            traverse(child, upstream, visited, level + 1);
         }
     }
 
-    private static void traverse(ExecutionTask current, BiConsumer<ExecutionTask, Integer> func, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
-        func.accept(current, level);
+    private static void traverse(ExecutionTask current, boolean upstream, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
+        System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + current.getOperator());
 
         if (visited.containsKey(current)) {
             return;
         }
 
-        Collection<ExecutionTask> consumers = Stream.of(current.getOutputChannels())
-            .flatMap(output -> output.getConsumers().stream())
-            .collect(Collectors.toList());
+        Collection<ExecutionTask> children;
 
-        for (ExecutionTask consumer : consumers) {
-            traverse(consumer, func, visited, level + 1);
+        if (upstream) {
+            children = Stream.of(current.getInputChannels())
+                .map(Channel::getProducer).collect(Collectors.toList());
+        } else {
+            children = Stream.of(current.getOutputChannels())
+                .flatMap(output -> output.getConsumers().stream())
+                .collect(Collectors.toList());
+        }
 
+        for (ExecutionTask child : children) {
+            traverse(child, upstream, visited, level + 1);
         }
     }
 }

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.core.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
+import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
+import org.apache.wayang.core.plan.executionplan.ExecutionTask;
+
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ExplainUtils {
+
+    private static final String INDENT = "  ";
+
+    public static void parsePlan(WayangPlan plan) {
+        System.out.println("== Wayang Plan ==");
+        HashMap<Operator, Collection<Operator>> tree = new HashMap<>();
+        Collection<Operator> sources = plan.collectReachableTopLevelSources();
+
+        for (Operator source : sources) {
+            traverse(source, tree, 0);
+        }
+    }
+
+    public static void parsePlan(ExecutionPlan plan) {
+        System.out.println("== Execution Plan ==");
+        HashMap<Operator, Collection<ExecutionTask>> tree = new HashMap<>();
+        Set<ExecutionTask> tasks = plan.collectAllTasks();
+
+        Collection<ExecutionTask> sources = tasks.stream()
+            .filter(task -> task.getOperator().isSource())
+            .collect(Collectors.toList());
+        System.out.println(sources);
+
+        for (ExecutionTask source : sources) {
+            traverse(source, tree, 0);
+        }
+    }
+
+    private static void traverse(Operator current, HashMap<Operator, Collection<Operator>> visited, int level) {
+        if (visited.containsKey(current)) {
+            return;
+        }
+
+        if (current instanceof OperatorAlternative) {
+            OperatorAlternative alts = (OperatorAlternative) current;
+            System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + alts.getAlternatives());
+        } else {
+            System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + current);
+        }
+
+        Collection<Operator> outputs = Stream.of(current.getAllOutputs())
+            .flatMap(output -> {
+                return output
+                    .getOccupiedSlots()
+                    .stream()
+                    .map(input -> input.getOwner());
+            })
+            .collect(Collectors.toList());
+
+        for (Operator output : outputs) {
+            traverse(output, visited, level + 1);
+        }
+    }
+
+    private static void traverse(ExecutionTask current, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
+        if (visited.containsKey(current)) {
+            return;
+        }
+
+        Collection<ExecutionTask> consumers = Stream.of(current.getOutputChannels())
+            .flatMap(output -> output.getConsumers().stream())
+            .collect(Collectors.toList());
+
+        System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + current.getOperator());
+
+        for (ExecutionTask consumer : consumers) {
+            traverse(consumer, visited, level + 1);
+
+        }
+    }
+}

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
@@ -19,12 +19,15 @@
 package org.apache.wayang.core.util;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.wayang.core.api.exception.WayangException;
 import org.apache.wayang.core.plan.executionplan.ExecutionPlan;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.OperatorAlternative;
 import org.apache.wayang.core.plan.executionplan.ExecutionTask;
 import org.apache.wayang.core.plan.executionplan.Channel;
+import org.apache.wayang.core.util.fs.FileSystem;
+import org.apache.wayang.core.util.fs.FileSystems;
 
 import java.util.List;
 import java.util.Set;
@@ -36,13 +39,18 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 
 public class ExplainUtils {
 
     public static final String INDENT = "  ";
 
-    public static void parsePlan(WayangPlan plan, boolean upstream) {
+    public static ExplainTreeNode parsePlan(WayangPlan plan, boolean upstream) {
         System.out.println("== Wayang Plan ==");
+        List<ExplainTreeNode> result = new ArrayList<>();
         HashMap<Operator, Collection<Operator>> tree = new HashMap<>();
         Collection<Operator> roots = plan.collectReachableTopLevelSources();
 
@@ -51,12 +59,20 @@ public class ExplainUtils {
         }
 
         for (Operator root : roots) {
-            traverse(root, upstream, tree, 0);
+            ExplainTreeNode rootNode = traverse(root, upstream, tree, 0);
+            result.add(rootNode);
         }
+
+        if (result.size() == 0) {
+            return null;
+        }
+
+        return result.get(0);
     }
 
-    public static void parsePlan(ExecutionPlan plan, boolean upstream) {
+    public static ExplainTreeNode parsePlan(ExecutionPlan plan, boolean upstream) {
         System.out.println("== Execution Plan ==");
+        List<ExplainTreeNode> result = new ArrayList<>();
         HashMap<Operator, Collection<ExecutionTask>> tree = new HashMap<>();
         Set<ExecutionTask> tasks = plan.collectAllTasks();
 
@@ -73,11 +89,18 @@ public class ExplainUtils {
         }
 
         for (ExecutionTask root : roots) {
-            traverse(root, upstream, tree, 0);
+            ExplainTreeNode rootNode = traverse(root, upstream, tree, 0);
+            result.add(rootNode);
         }
+
+        if (result.size() == 0) {
+            return null;
+        }
+
+        return result.get(0);
     }
 
-    private static void traverse(Operator current, boolean upstream, HashMap<Operator, Collection<Operator>> visited, int level) {
+    private static ExplainTreeNode traverse(Operator current, boolean upstream, HashMap<Operator, Collection<Operator>> visited, int level) {
         if (current instanceof OperatorAlternative) {
             OperatorAlternative alts = (OperatorAlternative) current;
             System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + alts.getAlternatives());
@@ -86,7 +109,7 @@ public class ExplainUtils {
         }
 
         if (visited.containsKey(current)) {
-            return;
+            return null;
         }
 
         Collection<Operator> children;
@@ -107,16 +130,22 @@ public class ExplainUtils {
                 .collect(Collectors.toList());
         }
 
+        ExplainTreeNode currentNode = new ExplainTreeNode();
+        currentNode.operator = current;
+
         for (Operator child : children) {
-            traverse(child, upstream, visited, level + 1);
+            ExplainTreeNode next = traverse(child, upstream, visited, level + 1);
+            currentNode.children.add(next);
         }
+
+        return currentNode;
     }
 
-    private static void traverse(ExecutionTask current, boolean upstream, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
+    private static ExplainTreeNode traverse(ExecutionTask current, boolean upstream, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
         System.out.println(StringUtils.repeat(ExplainUtils.INDENT, level) + "-+ " + current.getOperator());
 
         if (visited.containsKey(current)) {
-            return;
+            return null;
         }
 
         Collection<ExecutionTask> children;
@@ -130,8 +159,33 @@ public class ExplainUtils {
                 .collect(Collectors.toList());
         }
 
+        ExplainTreeNode currentNode = new ExplainTreeNode();
+        currentNode.operator = current.getOperator();
+
         for (ExecutionTask child : children) {
-            traverse(child, upstream, visited, level + 1);
+            ExplainTreeNode next = traverse(child, upstream, visited, level + 1);
+            currentNode.children.add(next);
+        }
+
+        return currentNode;
+    }
+
+    public static void write(ExplainTreeNode node, String path) {
+        final FileSystem fileSystem = FileSystems.getFileSystem(path).orElseThrow(
+                () -> new WayangException(String.format("No file system found for \"%s\".", path))
+        );
+
+        try (final BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(
+                        fileSystem.create(path), "UTF-8"
+                )
+        )) {
+            node.toJson().write(writer);
+            writer.newLine();
+            writer.flush();
+            writer.close();
+        }catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ExplainUtils.java
@@ -56,7 +56,6 @@ public class ExplainUtils {
         Collection<ExecutionTask> sources = tasks.stream()
             .filter(task -> task.getOperator().isSource())
             .collect(Collectors.toList());
-        System.out.println(sources);
 
         for (ExecutionTask source : sources) {
             traverse(source, tree, 0);
@@ -64,15 +63,15 @@ public class ExplainUtils {
     }
 
     private static void traverse(Operator current, HashMap<Operator, Collection<Operator>> visited, int level) {
-        if (visited.containsKey(current)) {
-            return;
-        }
-
         if (current instanceof OperatorAlternative) {
             OperatorAlternative alts = (OperatorAlternative) current;
             System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + alts.getAlternatives());
         } else {
             System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + current);
+        }
+
+        if (visited.containsKey(current)) {
+            return;
         }
 
         Collection<Operator> outputs = Stream.of(current.getAllOutputs())
@@ -90,6 +89,8 @@ public class ExplainUtils {
     }
 
     private static void traverse(ExecutionTask current, HashMap<Operator, Collection<ExecutionTask>> visited, int level) {
+        System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + current.getOperator());
+
         if (visited.containsKey(current)) {
             return;
         }
@@ -97,8 +98,6 @@ public class ExplainUtils {
         Collection<ExecutionTask> consumers = Stream.of(current.getOutputChannels())
             .flatMap(output -> output.getConsumers().stream())
             .collect(Collectors.toList());
-
-        System.out.println(StringUtils.repeat(INDENT, level) + "-+ " + current.getOperator());
 
         for (ExecutionTask consumer : consumers) {
             traverse(consumer, visited, level + 1);


### PR DESCRIPTION
References #417 

Users can define WayangPlans as usual, but instead of executing them, they can now use an explain command:

```java
// Debug into console
WayangContext.explain(wayangPlan, udfJars);

// Print to json files for later usage:

WayangContext.explain(wayangPlan, true, udfJars);
```

Example debug to console for WordCount:
```shell
== Wayang Plan ==
-+ [Alternative[[LocalCallbackSink[Collect result]]], Alternative[[JavaLocalCallbackSink[Collect result]]], Alternative[[SparkLocalCallbackSink[Collect result]]]]
  -+ [Alternative[[ReduceBy[Add counters]]], Alternative[[JavaReduceBy[Add counters]]], Alternative[[SparkReduceBy[Add counters]]]]
    -+ [Alternative[[Map[To lower case, add counter]]], Alternative[[JavaMap[To lower case, add counter]]], Alternative[[SparkMap[To lower case, add counter]]]]
      -+ [Alternative[[Filter[Filter empty words]]], Alternative[[JavaFilter[Filter empty words]]], Alternative[[SparkFilter[Filter empty words]]]]
        -+ [Alternative[[FlatMap[Split words]]], Alternative[[JavaFlatMap[Split words]]], Alternative[[SparkFlatMap[Split words]]]]
          -+ [Alternative[[TextFileSource[Load file]]], Alternative[[JavaTextFileSource[Load file]]], Alternative[[SparkTextFileSource[Load file]]]]

== Execution Plan ==
-+ JavaLocalCallbackSink[Collect result]
  -+ JavaReduceBy[Add counters]
    -+ JavaMap[To lower case, add counter]
      -+ JavaFilter[Filter empty words]
        -+ JavaFlatMap[Split words]
          -+ JavaTextFileSource[Load file]
```

The class `ExplainUtils` was added and allows to retrieve `ExplainTreeNodes` that can be used for further computations (maybe other file formats etc.). This class allows to specify upstream or downstream traversal of plans so that users can build trees that fit their needs.