### PR TITLE
Add explain utility to scala planBuilder

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -769,7 +769,7 @@ class DataQuanta[Out: ClassTag](val operator: ElementaryOperator, outputIndex: I
     sink.setName("explain()")
     this.connectTo(sink, 0)
 
-    // Do the execution.
+    // Do the explanation.
     this.planBuilder.sinks += sink
     this.planBuilder.buildAndExplain()
   }

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -762,6 +762,19 @@ class DataQuanta[Out: ClassTag](val operator: ElementaryOperator, outputIndex: I
     collector
   }
 
+  def explain(): Unit = {
+    // Set up the sink.
+    val collector = new java.util.LinkedList[Out]()
+    val sink = LocalCallbackSink.createCollectingSink(collector, dataSetType[Out])
+    sink.setName("explain()")
+    this.connectTo(sink, 0)
+
+    // Do the execution.
+    this.planBuilder.sinks += sink
+    this.planBuilder.buildAndExplain()
+  }
+
+
   /**
     * Write the data quanta in this instance to a text file. Triggers execution.
     *

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/PlanBuilder.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/PlanBuilder.scala
@@ -107,6 +107,14 @@ class PlanBuilder(wayangContext: WayangContext, private var jobName: String = nu
   }
 
   /**
+    * Build the [[org.apache.wayang.core.api.Job]] and explain it.
+    */
+  def buildAndExplain(): Unit = {
+    val plan: WayangPlan = new WayangPlan(this.sinks.toArray: _*)
+    this.wayangContext.explain(plan, this.udfJars.toArray: _*)
+  }
+
+  /**
     * Read a text file and provide it as a dataset of [[String]]s, one per line.
     *
     * @param url the URL of the text file


### PR DESCRIPTION
At this moment, the Scala API has no nice interface to use the new explain command.