### PR TITLE
Minor changes for compilation with raw mvn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pom.xml.*
 # VSCode
 .vscode
 .vscode/*
+
+# Scala Plugin for VSCode
+.metals

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,15 @@
         <scala.mayor.version>2.12</scala.mayor.version>
         <spark.version>3.1.2</spark.version>
 
+        <java.version>11</java.version>
+        <source.level>11</source.level>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <jaxb.version>2.2.11</jaxb.version>
+        <java-activation.version>1.1.1</java-activation.version>
+        <javax-annotation-api>1.3.2</javax-annotation-api>
+
         <assertj.version>3.17.2</assertj.version>
         <commons-io.version>2.5</commons-io.version>
         <guava.version>19.0</guava.version>

--- a/wayang-api/wayang-api-scala-java/pom.xml
+++ b/wayang-api/wayang-api-scala-java/pom.xml
@@ -61,6 +61,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-api-scala-java_2.11</artifactId>
+            <version>0.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
             <artifactId>wayang-utils-profile-db</artifactId>
             <version>0.7.1</version>
         </dependency>

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -215,6 +215,7 @@ class DataQuanta[Out: ClassTag](val operator: ElementaryOperator, outputIndex: I
     *
     * @param sampleSize   absolute size of the sample
     * @param datasetSize  optional size of the dataset to be sampled
+    * @param seed         the seed for the random sample
     * @param sampleMethod the [[SampleOperator.Methods]] to use for sampling
     * @return a new instance representing the [[FlatMapOperator]]'s output
     */

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/optimizer/cardinality/CardinalityEstimatorManager.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/optimizer/cardinality/CardinalityEstimatorManager.java
@@ -31,7 +31,7 @@ import org.apache.wayang.core.platform.ChannelInstance;
 import org.apache.wayang.core.platform.ExecutionState;
 import org.apache.wayang.core.platform.Junction;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Map;

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/platform/CrossPlatformExecutor.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/platform/CrossPlatformExecutor.java
@@ -34,7 +34,7 @@ import org.apache.wayang.core.profiling.InstrumentationStrategy;
 import org.apache.wayang.core.util.AbstractReferenceCountable;
 import org.apache.wayang.core.util.Formats;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ReflectionUtils.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/util/ReflectionUtils.java
@@ -21,7 +21,7 @@ package org.apache.wayang.core.util;
 import org.apache.commons.lang3.Validate;
 import org.apache.wayang.core.api.exception.WayangException;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;;
+import org.apache.logging.log4j.Logger;
 
 import java.io.InputStream;
 import java.lang.reflect.Constructor;

--- a/wayang-docs/pom.xml
+++ b/wayang-docs/pom.xml
@@ -18,12 +18,14 @@
   under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    
     <parent>
         <artifactId>wayang</artifactId>
         <groupId>org.apache.wayang</groupId>
-        <version>0.7.1-SNAPSHOT</version>
+        <version>0.7.1</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>wayang-docs</artifactId>
     <description>Generation of the documentation with jekyll</description>


### PR DESCRIPTION
When opening Wayang in my IDE it produced many errors, 

![image](https://github.com/apache/incubator-wayang/assets/9947148/c4d8afa2-7efe-4b6e-8d0d-07e54aa07c4b)

This PR fixes all of them (at least for my setup).

The main issue is that a default Java compile level is not set in the root POM.xml file, and therefore my IDE(vscode) does not know what to compile. While it is possible to add this as a configuration inside an individual's setup .vscode for Visual Code, I would still suggest moving it to a default setting. Because 1. the .vscode settings file is git ignored and 2. the IDE automatically picks up the default value set in the root parameters of the POM.xml.


The second issue i had was with wayang-api/wayang-api-scala-java/pom.xml. 
Unfortunately, my IDE did not compile correctly without adding a recursive dependency on its package:

```
<dependency>
    <groupId>org.apache.wayang</groupId>
    <artifactId>wayang-api-scala-java_2.11</artifactId>
    <version>0.7.1</version>
</dependency>
```

Maybe there is a better way to handle this?

Finally, there were two minor bugs: 1. the docs pom contained the -SNAPSHOT when referencing the root repository, and 2. some imports contained an extra `;`.


Afterwards:

![image](https://github.com/apache/incubator-wayang/assets/9947148/a396d0f8-b67d-4af8-9f30-ccb99e297f7f)


