### PR TITLE
Set logLevel on WayangContext to allow doing it without conf file

### DIFF
--- a/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
+++ b/wayang-commons/wayang-core/src/main/java/org/apache/wayang/core/api/WayangContext.java
@@ -30,6 +30,9 @@ import org.apache.wayang.core.util.ExplainUtils;
 import org.apache.wayang.core.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 
 /**
  * This is the entry point for users to work with Wayang.
@@ -206,5 +209,15 @@ public class WayangContext {
             this.cardinalityRepository = new CardinalityRepository(this.configuration);
         }
         return this.cardinalityRepository;
+    }
+
+    public WayangContext setLogLevel(Level level) {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        org.apache.logging.log4j.core.config.Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+        loggerConfig.setLevel(level);
+        ctx.updateLoggers();
+
+        return this;
     }
 }


### PR DESCRIPTION
This proposes a functional interface to change the Loggers level with the `WayangContext`:

```java
context.setLogLevel(Level.ERROR);
```

The change provides better ergonomics and prevents having to fiddle with configuration files, when Context objects etc. can be created during plan building. Furthermore, this aligns with the API presented in other Apache projects like [Spark](https://github.com/apache/spark/blob/df5ef91f44bacf60b39bccecc049eb8cb5714b39/core/src/main/scala/org/apache/spark/SparkContext.scala#L398) 
