### PR TITLE
use m-jar-p version configured in parent

### DIFF
--- a/wayang-applications/pom.xml
+++ b/wayang-applications/pom.xml
@@ -120,14 +120,4 @@
         </dependency>
 
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
solves reproducible build issue found in 1.0.0 release:
https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/wayang/README.md