### PR TITLE
More testing for the sql-api & enable custom calcite models for TableScanVisitor

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
@@ -21,13 +21,35 @@ package org.apache.wayang.api.sql.calcite.converter;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.wayang.api.sql.calcite.rel.*;
+import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 
 public class WayangRelConverter {
+    private final Configuration configuration;
 
-    public Operator convert(RelNode node) {
-        if(node instanceof WayangTableScan) {
-            return new WayangTableScanVisitor(this).visit((WayangTableScan)node);
+    public WayangRelConverter(final Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    public WayangRelConverter() {
+        this.configuration = null;
+    }
+
+    /**
+     * Some visitors may rely on configuration like the
+     * {@link WayangTableScanVisitor}, that uses it
+     * to specify its calcite schema when fetching from files on disk
+     * 
+     * @return {@link Configuration}, or null if {@link WayangRelConverter} is not
+     *         constructed with one.
+     */
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public Operator convert(final RelNode node) {
+        if (node instanceof WayangTableScan) {
+            return new WayangTableScanVisitor(this).visit((WayangTableScan) node);
         } else if (node instanceof WayangProject) {
             return new WayangProjectVisitor(this).visit((WayangProject) node);
         } else if (node instanceof WayangFilter) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
@@ -28,52 +28,57 @@ import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.postgres.operators.PostgresTableSource;
 import org.apache.wayang.basic.data.Record;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
+import java.util.stream.Collectors;
 
 //TODO: create tablesource with column types
 //TODO: support other sources
 public class WayangTableScanVisitor extends WayangRelNodeVisitor<WayangTableScan> {
-    WayangTableScanVisitor(WayangRelConverter wayangRelConverter) {
+    WayangTableScanVisitor(final WayangRelConverter wayangRelConverter) {
         super(wayangRelConverter);
     }
 
     @Override
-    Operator visit(WayangTableScan wayangRelNode) {
+    Operator visit(final WayangTableScan wayangRelNode) {
 
-        String tableName = wayangRelNode.getTableName();
-        List<String> columnNames = wayangRelNode.getColumnNames();
+        final String tableName = wayangRelNode.getTableName();
+        final List<String> columnNames = wayangRelNode.getColumnNames();
 
         // Get the source platform for this table
-        String tableSource = wayangRelNode.getTable().getQualifiedName().get(0);
+        final String tableSource = wayangRelNode.getTable().getQualifiedName().get(0);
+
         if (tableSource.equals("postgres")) {
             return new PostgresTableSource(tableName, columnNames.toArray(new String[]{}));
         }
+
         if (tableSource.equals("fs")) {
             ModelParser modelParser;
+            System.out.println("this config: " + this.wayangRelConverter.getConfiguration());
             try {
-                modelParser = new ModelParser();
-            } catch (Exception e) {
+                modelParser = this.wayangRelConverter.getConfiguration() == null
+                        ? new ModelParser()
+                        : new ModelParser(this.wayangRelConverter.getConfiguration());
+            } catch (final Exception e) {
                 throw new RuntimeException(e);
             }
-            RelDataType rowType = wayangRelNode.getRowType();
-            List<RelDataType> fieldTypes = new ArrayList<>();
-            for (RelDataTypeField field : rowType.getFieldList()) {
-                fieldTypes.add(field.getType());
-            }
-            String url = String.format("file:/%s/%s.csv", modelParser.getFsPath(), wayangRelNode.getTableName());
 
-            String separator = modelParser.getSeparator();
+            final List<RelDataType> fieldTypes = wayangRelNode.getRowType().getFieldList().stream()
+                    .map(RelDataTypeField::getType)
+                    .collect(Collectors.toList());
+
+            final String url = String.format("file:/%s/%s.csv", modelParser.getFsPath(), wayangRelNode.getTableName());
+
+            final String separator = modelParser.getSeparator();
 
             if (Objects.equals(separator, "")) {
-                return new JavaCSVTableSource(url,
+                return new JavaCSVTableSource<>(url,
                         DataSetType.createDefault(Record.class), fieldTypes);
             } else {
-                return new JavaCSVTableSource(url,
+                return new JavaCSVTableSource<>(url,
                         DataSetType.createDefault(Record.class), fieldTypes, separator.charAt(0));
             }
-        } else throw new RuntimeException("Source not supported");
+        } else
+            throw new RuntimeException("Source not supported");
     }
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangTableScanVisitor.java
@@ -54,7 +54,6 @@ public class WayangTableScanVisitor extends WayangRelNodeVisitor<WayangTableScan
 
         if (tableSource.equals("fs")) {
             ModelParser modelParser;
-            System.out.println("this config: " + this.wayangRelConverter.getConfiguration());
             try {
                 modelParser = this.wayangRelConverter.getConfiguration() == null
                         ? new ModelParser()

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
@@ -50,6 +50,7 @@ import org.apache.wayang.api.sql.calcite.converter.WayangRelConverter;
 import org.apache.wayang.api.sql.calcite.schema.WayangSchema;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.operators.LocalCallbackSink;
+import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 
@@ -219,6 +220,16 @@ public class Optimizer {
         LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
 
         Operator op = new WayangRelConverter().convert(relNode);
+
+        op.connectTo(0, sink, 0);
+        return new WayangPlan(sink);
+    }
+
+    public WayangPlan convertWithConfig(RelNode relNode, Configuration configuration, Collection<Record> collector) {
+
+        LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
+
+        Operator op = new WayangRelConverter(configuration).convert(relNode);
 
         op.connectTo(0, sink, 0);
         return new WayangPlan(sink);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/ModelParser.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/ModelParser.java
@@ -39,10 +39,32 @@ public class ModelParser {
     }
 
     public ModelParser(Configuration configuration) throws IOException, ParseException {
-        this.configuration = configuration;
-        Object obj = new JSONParser().parse(new FileReader("wayang-api/wayang-api-sql/src/main/resources/model.json"));
-        this.json = (JSONObject) obj;
+        String calciteModel = "{\"calcite\"" + configuration.getStringProperty("wayang.calcite.model") + ",\"separator\":\";\"}";
 
+        this.configuration = configuration;
+        Object obj = new JSONParser().parse(calciteModel);
+        System.out.println("obj: " + obj);
+        this.json = (JSONObject) obj;
+    }
+
+    /**
+     * This method allows you to specify the Calcite path, useful for testing.
+     * See also {@link #ModelParser(Configuration)} and {@link #ModelParser()}.
+     *
+     * @param configuration    An empty configuration. Usage:
+     *                         {@code Configuration configuration = new ModelParser(new Configuration(), calciteModelPath).setProperties();}
+     * @param calciteModelPath Path to the JSON object containing the Calcite
+     *                         model/schema.
+     * @throws IOException    If an I/O error occurs.
+     * @throws ParseException If unable to parse the file at
+     *                        {@code calciteModelPath}.
+     */
+    public ModelParser(Configuration configuration, String calciteModelPath) throws IOException, ParseException {
+        this.configuration = configuration;
+        FileReader fr = new FileReader(calciteModelPath);
+        Object obj = new JSONParser().parse(fr);
+
+        this.json = (JSONObject) obj;
     }
 
     public Configuration setProperties() {

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -17,40 +17,324 @@
 
 package org.apache.wayang.api.sql;
 
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
+
 import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
 import org.apache.wayang.api.sql.calcite.optimizer.Optimizer;
 import org.apache.wayang.api.sql.calcite.rules.WayangRules;
+import org.apache.wayang.api.sql.calcite.schema.SchemaUtils;
 import org.apache.wayang.api.sql.calcite.schema.WayangSchema;
 import org.apache.wayang.api.sql.calcite.schema.WayangSchemaBuilder;
 import org.apache.wayang.api.sql.calcite.schema.WayangTable;
 import org.apache.wayang.api.sql.calcite.schema.WayangTableBuilder;
+import org.apache.wayang.api.sql.calcite.utils.ModelParser;
+import org.apache.wayang.api.sql.calcite.utils.PrintUtils;
+import org.apache.wayang.api.sql.context.SqlContext;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.plan.wayangplan.Operator;
 import org.apache.wayang.core.plan.wayangplan.PlanTraversal;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
+import org.apache.wayang.java.Java;
+import org.apache.wayang.basic.data.Record;
 
+import org.json.simple.parser.ParseException;
+
+import org.junit.Test;
+
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
-
+import java.util.Properties;
 
 public class SqlToWayangRelTest {
 
+    /**
+     * Method for building {@link WayangPlan}s useful for testing, benchmarking and
+     * other
+     * usages where you want to handle the intermediate {@link WayangPlan}
+     * 
+     * @param sql     sql query string with the {@code ;} cut off
+     * @param udfJars
+     * @return a {@link WayangPlan} of a given sql string
+     * @throws SqlParseException
+     * @throws SQLException
+     */
+    public Tuple2<Collection<Record>, WayangPlan> buildCollectorAndWayangPlan(final SqlContext context,
+            final String sql, final String... udfJars) throws SqlParseException, SQLException {
+        final Properties configProperties = Optimizer.ConfigProperties.getDefaults();
+        final RelDataTypeFactory relDataTypeFactory = new JavaTypeFactoryImpl();
+
+        final Optimizer optimizer = Optimizer.create(
+                SchemaUtils.getSchema(context.getConfiguration()),
+                configProperties,
+                relDataTypeFactory);
+
+        final SqlNode sqlNode = optimizer.parseSql(sql);
+        final SqlNode validatedSqlNode = optimizer.validate(sqlNode);
+        final RelNode relNode = optimizer.convert(validatedSqlNode);
+
+        final RuleSet rules = RuleSets.ofList(
+                CoreRules.FILTER_INTO_JOIN,
+                WayangRules.WAYANG_TABLESCAN_RULE,
+                WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
+                WayangRules.WAYANG_PROJECT_RULE,
+                WayangRules.WAYANG_FILTER_RULE,
+                WayangRules.WAYANG_JOIN_RULE,
+                WayangRules.WAYANG_AGGREGATE_RULE);
+
+        final RelNode wayangRel = optimizer.optimize(
+                relNode,
+                relNode.getTraitSet().plus(WayangConvention.INSTANCE),
+                rules);
+
+        PrintUtils.print("Optimized tree: ", wayangRel);
+        final Collection<Record> collector = new ArrayList<>();
+        final WayangPlan wayangPlan = optimizer.convertWithConfig(wayangRel, context.getConfiguration(),
+                collector);
+
+        return new Tuple2<>(collector, wayangPlan);
+    }
+
+    //@Test
+    public void javaMultiConditionJoin() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+        // SELECT acc.location, count(*) FROM postgres.site
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex JOIN fs.exampleRefToRef ON largeLeftTableIndex.NAMEA = exampleRefToRef.NAMEA AND largeLeftTableIndex.NAMEB = exampleRefToRef.NAMEB");
+        final Collection<Record> collector = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+
+        System.out.println("plan " + wayangPlan);
+        // except reduce by
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
+            node.addTargetPlatform(Java.platform());
+        });
+
+        sqlContext.execute(wayangPlan);
+        final Collection<org.apache.wayang.basic.data.Record> result = collector;
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+
+        final Record rec = result.stream().findFirst().get();
+    }
+
+    //@Test
+    public void aggregateCountInJavaWithIntegers() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/model-example-min.json", "/data/exampleInt.csv");
+        // SELECT acc.location, count(*) FROM postgres.site
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT exampleInt.NAMEC, COUNT(*) FROM fs.exampleInt GROUP BY NAMEC");
+        final Collection<Record> collector = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+
+        System.out.println("plan " + wayangPlan);
+
+        // except reduce by
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
+            node.addTargetPlatform(Java.platform());
+        });
+
+        sqlContext.execute(wayangPlan);
+        final Collection<org.apache.wayang.basic.data.Record> result = collector;
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+
+        final Record rec = result.stream().findFirst().get();
+        assert (rec.size() == 2);
+        assert (rec.getInt(1) == 3);
+    }
+
+    //@Test
+    public void aggregateCountInJava() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+        // SELECT acc.location, count(*) FROM postgres.site
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT largeLeftTableIndex.NAMEC, COUNT(*) FROM fs.largeLeftTableIndex GROUP BY NAMEC");
+        final Collection<Record> collector = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+
+        System.out.println("plan " + wayangPlan);
+        // except reduce by
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
+            node.addTargetPlatform(Java.platform());
+        });
+        sqlContext.execute(wayangPlan);
+        final Collection<org.apache.wayang.basic.data.Record> result = collector;
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+
+        final Record rec = result.stream().findFirst().get();
+        assert (rec.size() == 2);
+        assert (rec.getInt(1) == 3);
+    }
+
+    //@Test
+    public void filterIsNull() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex WHERE (largeLeftTableIndex.NAMEA IS NULL)" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+        assert (result.size() == 0);
+    }
+
+    //@Test
+    public void filterIsNotValue() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex WHERE (largeLeftTableIndex.NAMEA <> 'test1')" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+        assert (!result.stream().anyMatch(record -> record.getField(0).equals("test1")));
+    }
+
+    // @Test
+    public void filterIsNotNull() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex WHERE (largeLeftTableIndex.NAMEA IS NOT NULL)" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+        assert (!result.stream().anyMatch(record -> record.getField(0).equals(null)));
+    }
+
+    // @Test
+    public void filterWithNotLike() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex WHERE (largeLeftTableIndex.NAMEA NOT LIKE '_est1')" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+        assert (!result.stream().anyMatch(record -> record.getString(0).equals("test1")));
+    }
+
+    // @Test
+    public void filterWithLike() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex WHERE (largeLeftTableIndex.NAMEA LIKE '_est1' OR largeLeftTableIndex.NAMEA LIKE 't%')" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+    }
+
+    // @Test
+    public void joinWithLargeLeftTableIndexCorrect() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex AS na INNER JOIN fs.largeLeftTableIndex AS nb ON na.NAMEB = nb.NAMEA " //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+    }
+
+    // @Test
+    public void joinWithLargeLeftTableIndexMirrorAlias() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json",
+                "/data/largeLeftTableIndex.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.largeLeftTableIndex AS na INNER JOIN fs.largeLeftTableIndex AS nb ON nb.NAMEB = na.NAMEA " //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+    }
+
+    // @Test
+    public void exampleFilterTableRefToTableRef() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json", "/data/exampleRefToRef.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.exampleRefToRef WHERE exampleRefToRef.NAMEA = exampleRefToRef.NAMEB" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        System.out.println("Printing results");
+        result.stream().forEach(System.out::println);
+    }
+
+    // @Test
+    public void exampleMinWithStrings() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/model-example-min.json", "/data/exampleMin.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT MIN(exampleMin.NAME) FROM fs.exampleMin" //
+        );
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        assert (result.stream().findAny().get().getString(0).equals("AA"));
+    }
+
     public void test_simple_sql() throws Exception {
-        WayangTable customer = WayangTableBuilder.build("customer")
+        final WayangTable customer = WayangTableBuilder.build("customer")
                 .addField("id", SqlTypeName.INTEGER)
                 .addField("name", SqlTypeName.VARCHAR)
                 .addField("age", SqlTypeName.INTEGER)
                 .withRowCount(100)
                 .build();
 
-        WayangTable orders = WayangTableBuilder.build("orders")
+        final WayangTable orders = WayangTableBuilder.build("orders")
                 .addField("id", SqlTypeName.INTEGER)
                 .addField("cid", SqlTypeName.INTEGER)
                 .addField("price", SqlTypeName.DECIMAL)
@@ -58,70 +342,97 @@ public class SqlToWayangRelTest {
                 .withRowCount(100)
                 .build();
 
-        WayangSchema wayangSchema = WayangSchemaBuilder.build("exSchema")
+        final WayangSchema wayangSchema = WayangSchemaBuilder.build("exSchema")
                 .addTable(customer)
                 .addTable(orders)
                 .build();
 
-        Optimizer optimizer = Optimizer.create(wayangSchema);
+        final Optimizer optimizer = Optimizer.create(wayangSchema);
 
-//        String sql = "select c.name, c.age from customer c where (c.age < 40 or c.age > 60) and \'alex\' = c.name";
-//        String sql = "select c.age from customer c";
-        String sql = "select c.name, c.age, o.price from customer c join orders o on c.id = o.cid where c.age > 40 " +
+        // String sql = "select c.name, c.age from customer c where (c.age < 40 or c.age
+        // > 60) and \'alex\' = c.name";
+        // String sql = "select c.age from customer c";
+        final String sql = "select c.name, c.age, o.price from customer c join orders o on c.id = o.cid where c.age > 40 "
+                +
                 "and o" +
                 ".price < 100";
 
-
-        SqlNode sqlNode = optimizer.parseSql(sql);
-        SqlNode validatedSqlNode = optimizer.validate(sqlNode);
-        RelNode relNode = optimizer.convert(validatedSqlNode);
+        final SqlNode sqlNode = optimizer.parseSql(sql);
+        final SqlNode validatedSqlNode = optimizer.validate(sqlNode);
+        final RelNode relNode = optimizer.convert(validatedSqlNode);
 
         print("After parsing", relNode);
 
-
-        RuleSet rules = RuleSets.ofList(
+        final RuleSet rules = RuleSets.ofList(
                 WayangRules.WAYANG_TABLESCAN_RULE,
                 WayangRules.WAYANG_PROJECT_RULE,
                 WayangRules.WAYANG_FILTER_RULE,
                 WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
                 WayangRules.WAYANG_JOIN_RULE,
-                WayangRules.WAYANG_AGGREGATE_RULE
-        );
+                WayangRules.WAYANG_AGGREGATE_RULE);
 
-        RelNode wayangRel = optimizer.optimize(
+        final RelNode wayangRel = optimizer.optimize(
                 relNode,
                 relNode.getTraitSet().plus(WayangConvention.INSTANCE),
-                rules
-        );
+                rules);
 
         print("After rel to wayang conversion", wayangRel);
 
+        // WayangPlan plan = optimizer.convert(wayangRel);
 
-        //WayangPlan plan = optimizer.convert(wayangRel);
-
-        //print("After Translating to WayangPlan", plan);
-
-
+        // print("After Translating to WayangPlan", plan);
 
     }
 
+    private SqlContext createSqlContext(final String calciteResourceName, final String tableResourceName)
+            throws IOException, ParseException, SQLException {
 
-    private void print(String header, WayangPlan plan) {
-        StringWriter sw = new StringWriter();
+        final String calciteModelPath = SqlAPI.class.getResource(calciteResourceName).getPath();
+        assert (calciteModelPath != null && calciteModelPath != "")
+                : "Could not get calcite model resource from path: " + calciteResourceName;
+
+        final Configuration configuration = new ModelParser(new Configuration(), calciteModelPath)
+                .setProperties();
+        assert (configuration != null)
+                : "Could not get configuration with calcite model path: " + calciteModelPath;
+
+        final String dataPath = SqlAPI.class.getResource(tableResourceName).getPath();
+        assert (dataPath != null && dataPath != "")
+                : "Could not get table resource from path: " + tableResourceName;
+
+        configuration.setProperty("wayang.fs.table.url", dataPath);
+
+        configuration.setProperty(
+                "wayang.ml.executions.file",
+                "mle" + ".txt");
+
+        configuration.setProperty(
+                "wayang.ml.optimizations.file",
+                "mlo" + ".txt");
+
+        configuration.setProperty("wayang.ml.experience.enabled", "false");
+
+        return new SqlContext(configuration);
+    }
+
+    private void print(final String header, final WayangPlan plan) {
+        final StringWriter sw = new StringWriter();
         sw.append(header).append(":").append("\n");
 
-        final Collection<Operator> operators = PlanTraversal.upstream().traverse(plan.getSinks()).getTraversedNodes();
+        final Collection<Operator> operators = PlanTraversal.upstream().traverse(plan.getSinks())
+                .getTraversedNodes();
         operators.forEach(o -> sw.append(o.toString()));
 
         System.out.println(sw.toString());
     }
 
-    private void print(String header, RelNode relTree) {
-        StringWriter sw = new StringWriter();
+    private void print(final String header, final RelNode relTree) {
+        final StringWriter sw = new StringWriter();
 
         sw.append(header).append(":").append("\n");
 
-        RelWriterImpl relWriter = new RelWriterImpl(new PrintWriter(sw), SqlExplainLevel.ALL_ATTRIBUTES, true);
+        final RelWriterImpl relWriter = new RelWriterImpl(new PrintWriter(sw), SqlExplainLevel.ALL_ATTRIBUTES,
+                true);
 
         relTree.explain(relWriter);
 

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -101,7 +101,6 @@ public class SqlToWayangRelTest {
                 relNode.getTraitSet().plus(WayangConvention.INSTANCE),
                 rules);
 
-        PrintUtils.print("Optimized tree: ", wayangRel);
         final Collection<Record> collector = new ArrayList<>();
         final WayangPlan wayangPlan = optimizer.convertWithConfig(wayangRel, context.getConfiguration(),
                 collector);
@@ -119,7 +118,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> collector = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        System.out.println("plan " + wayangPlan);
         // except reduce by
         PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
             node.addTargetPlatform(Java.platform());
@@ -127,8 +125,6 @@ public class SqlToWayangRelTest {
 
         sqlContext.execute(wayangPlan);
         final Collection<org.apache.wayang.basic.data.Record> result = collector;
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
 
         final Record rec = result.stream().findFirst().get();
     }
@@ -142,8 +138,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> collector = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        System.out.println("plan " + wayangPlan);
-
         // except reduce by
         PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
             node.addTargetPlatform(Java.platform());
@@ -151,8 +145,6 @@ public class SqlToWayangRelTest {
 
         sqlContext.execute(wayangPlan);
         final Collection<org.apache.wayang.basic.data.Record> result = collector;
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
 
         final Record rec = result.stream().findFirst().get();
         assert (rec.size() == 2);
@@ -169,16 +161,12 @@ public class SqlToWayangRelTest {
         final Collection<Record> collector = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        System.out.println("plan " + wayangPlan);
         // except reduce by
         PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> {
             node.addTargetPlatform(Java.platform());
         });
         sqlContext.execute(wayangPlan);
         final Collection<org.apache.wayang.basic.data.Record> result = collector;
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
-
         final Record rec = result.stream().findFirst().get();
         assert (rec.size() == 2);
         assert (rec.getInt(1) == 3);
@@ -195,9 +183,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
         assert (result.size() == 0);
     }
 
@@ -212,9 +197,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
         assert (!result.stream().anyMatch(record -> record.getField(0).equals("test1")));
     }
 
@@ -229,9 +211,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
         assert (!result.stream().anyMatch(record -> record.getField(0).equals(null)));
     }
 
@@ -246,9 +225,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
         assert (!result.stream().anyMatch(record -> record.getString(0).equals("test1")));
     }
 
@@ -263,8 +239,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
     }
 
     // @Test
@@ -278,8 +252,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
     }
 
     // @Test
@@ -293,8 +265,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
     }
 
     // @Test
@@ -307,9 +277,6 @@ public class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
         sqlContext.execute(wayangPlan);
-
-        System.out.println("Printing results");
-        result.stream().forEach(System.out::println);
     }
 
     // @Test

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleInt.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleInt.csv
@@ -1,0 +1,4 @@
+NAMEA:String,NAMEB:int,NAMEC:int
+test1;1;1
+;1;1
+test2;2;1

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleMin.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleMin.csv
@@ -1,0 +1,4 @@
+NAME:string
+AA
+AB
+AC

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleRefToRef.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleRefToRef.csv
@@ -1,0 +1,4 @@
+NAMEA:string,NAMEB:string
+test1;test1
+;test2
+test2;

--- a/wayang-api/wayang-api-sql/src/test/resources/data/largeLeftTableIndex.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/largeLeftTableIndex.csv
@@ -1,0 +1,4 @@
+NAMEA:string,NAMEB:string,NAMEC:string
+test1;test1;test2
+;test2;test2
+test2;;test2

--- a/wayang-api/wayang-api-sql/src/test/resources/model-example-min.json
+++ b/wayang-api/wayang-api-sql/src/test/resources/model-example-min.json
@@ -1,0 +1,20 @@
+{
+    "calcite": {
+      "version": "1.0",
+      "defaultSchema": "wayang",
+      "schemas": [
+        {
+          "name": "fs",
+          "type": "custom",
+          "factory": "org.apache.calcite.adapter.file.FileSchemaFactory",
+          "operand": {
+            "directory": "//var/www/html/wayang-api/wayang-api-sql/src/test/resources/data"
+          }
+        }
+      ]
+    },
+    "separator": ";"
+  }
+  
+  
+  


### PR DESCRIPTION
I've added a bunch of tests that tests common sql queries that aren't yet supported in the sql-api,
I've left them commented so it doesn't discourage people from pushing working commits yet. I'll have some implementations coming from my personal fork once I verify they are working on 1.0.