### PR TITLE
[CI] support parallel builds with JDK 11 and JDK 17

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,25 +32,28 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check License Header
         uses: apache/skywalking-eyes/header@main
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [11, 17]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          java-version:  11
-          distribution: 'adopt'      
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
       - name: Install Protoc
         run: sudo apt install -y protobuf-compiler
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven
+          key: ${{ runner.os }}-maven-${{ matrix.java }}
       - name: Build And Install
         run: ./mvnw clean install -B -Dmaven.test.skip=true
       - name: Run Unit tests

--- a/pom.xml
+++ b/pom.xml
@@ -637,9 +637,8 @@
                 <plugins>
                     <!-- Make some additional properties available to simplify keeping some content up to date -->
                     <plugin>
-                        <groupId>org.codehaus.gmaven</groupId>
-                        <artifactId>groovy-maven-plugin</artifactId>
-                        <version>2.1.1</version>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
                         <executions>
                             <!-- Do some pre-build checks and report any findings to the user -->
                             <execution>
@@ -977,6 +976,11 @@
                     <version>2.7.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>4.1.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.7</version>
@@ -991,9 +995,8 @@
         <plugins>
             <!-- Make some additional properties available to simplify keeping some content up to date -->
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <version>2.1.1</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <executions>
                     <!-- Do some pre-build checks and report any findings to the user -->
                     <execution>


### PR DESCRIPTION
- support parallel builds with JDK 11 and JDK 17
- replace groovy-maven-plugin with gmavenplus-plugin, as groovy-maven-plugin is no longer actively maintained and does not support JDK 17.