### PR TITLE
Fix join key extraction for python join operator

### DIFF
--- a/python/src/pywy/core/serializer.py
+++ b/python/src/pywy/core/serializer.py
@@ -53,12 +53,13 @@ class JSONSerializer:
 
         json_operator["data"] = {}
 
-        if hasattr(operator, "input_type"):
-            if operator.input_type is not None:
-                json_operator["data"]["inputType"] = ndim_from_type(operator.input_type).to_json()
-        if hasattr(operator, "output_type"):
-            if operator.output_type is not None:
-                json_operator["data"]["outputType"] = ndim_from_type(operator.output_type).to_json()
+        if operator.json_name != "join":
+            if hasattr(operator, "input_type"):
+                if operator.input_type is not None:
+                    json_operator["data"]["inputType"] = ndim_from_type(operator.input_type).to_json()
+            if hasattr(operator, "output_type"):
+                if operator.output_type is not None:
+                    json_operator["data"]["outputType"] = ndim_from_type(operator.output_type).to_json()
 
         if operator.json_name == "filter":
             json_operator["data"]["udf"] = base64.b64encode(cloudpickle.dumps(operator.use_predicate)).decode('utf-8')

--- a/python/src/pywy/operators/binary.py
+++ b/python/src/pywy/operators/binary.py
@@ -63,10 +63,11 @@ class JoinOperator(BinaryToUnaryOperator):
             output_type: GenericTco
         ):
         super().__init__("Join", input_type, output_type)
-        self.this_key_function = lambda g: this_key_function(next(g))
+        self.this_key_function = lambda g: this_key_function(ast.literal_eval(next(g)))
         self.that = that
-        self.that_key_function = lambda g: that_key_function(next(g))
+        self.that_key_function = lambda g: that_key_function(ast.literal_eval(next(g)))
         self.json_name = "join"
+
 
 
 class DLTrainingOperator(BinaryToUnaryOperator):

--- a/python/src/pywy/tests/join_test.py
+++ b/python/src/pywy/tests/join_test.py
@@ -1,0 +1,45 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import unittest
+#from typing import Tuple, Callable, Iterable
+from pywy.dataquanta import WayangContext
+from unittest.mock import Mock
+from pywy.platforms.java import JavaPlugin
+from pywy.platforms.spark import SparkPlugin
+
+class TestJoin(unittest.TestCase):
+    def test_to_json(self):
+        ctx = WayangContext() \
+           .register({JavaPlugin, SparkPlugin})
+
+        left = ctx.textfile("file:///var/www/html/data/left.csv").map(lambda x: tuple(x.split(",")), (int, str), (int, str))
+        right = ctx.textfile("file:///var/www/html/data/right.csv").map(lambda x: tuple(x.split(",")), (int, str), (int, str))
+
+        def join_key(item: (int, str)) -> (int):
+            print(f"join item {item}")
+            print(f"key: {item[0]}")
+
+            return item[0]
+
+        join = left.join(join_key, right, join_key) \
+            .store_textfile("file:///var/www/html/data/join-out-python.txt")
+
+        self.assertEqual(True, True)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/pywy/tests/sandbox.py
+++ b/python/src/pywy/tests/sandbox.py
@@ -1,6 +1,0 @@
-import ast
-
-candidate = "1,2"
-
-tupl = ast.literal_eval(candidate)
-

--- a/python/src/pywy/tests/sandbox.py
+++ b/python/src/pywy/tests/sandbox.py
@@ -1,0 +1,6 @@
+import ast
+
+candidate = "1,2"
+
+tupl = ast.literal_eval(candidate)
+

--- a/wayang-api/wayang-api-python/src/main/java/org/apache/wayang/api/python/function/WrappedTransformationDescriptor.java
+++ b/wayang-api/wayang-api-python/src/main/java/org/apache/wayang/api/python/function/WrappedTransformationDescriptor.java
@@ -39,7 +39,12 @@ public class WrappedTransformationDescriptor<Input, Output> extends Transformati
                 input.add(item);
                 final PythonWorkerManager<Input, Output> manager = new PythonWorkerManager<>(serializedUDF, input);
                 final Iterable<Output> output = manager.execute();
-                return output.iterator().next();
+
+                if (output.iterator().hasNext()) {
+                    return output.iterator().next();
+                }
+
+                return null;
             },
             inputTypeClass,
             outputTypeClass


### PR DESCRIPTION
The python join operator's key extraction didn't work properly due to incorrect input handling. 
This resulted in a cartesian product, as both keys were null.
