### PR TITLE
add support for cross joins in the sql-api

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangCrossJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangCrossJoinVisitor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.api.sql.calcite.converter;
+
+import java.io.Serializable;
+
+import org.apache.wayang.api.sql.calcite.converter.functions.FlattenJoinResult;
+import org.apache.wayang.api.sql.calcite.rel.WayangJoin;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.basic.operators.CartesianOperator;
+import org.apache.wayang.basic.operators.MapOperator;
+import org.apache.wayang.core.function.FunctionDescriptor.SerializableFunction;
+import org.apache.wayang.core.plan.wayangplan.Operator;
+import org.apache.wayang.core.util.ReflectionUtils;
+
+public class WayangCrossJoinVisitor extends WayangRelNodeVisitor<WayangJoin> implements Serializable {
+
+    WayangCrossJoinVisitor(final WayangRelConverter wayangRelConverter) {
+        super(wayangRelConverter);
+    }
+
+    @Override
+    Operator visit(final WayangJoin wayangRelNode) {
+        final Operator childOpLeft = wayangRelConverter.convert(wayangRelNode.getInput(0));
+        final Operator childOpRight = wayangRelConverter.convert(wayangRelNode.getInput(1));
+
+        final CartesianOperator<Record, Record> join = new CartesianOperator<Record, Record>(
+                Record.class,
+                Record.class);
+
+        childOpLeft.connectTo(0, join, 0);
+        childOpRight.connectTo(0, join, 1);
+
+        final SerializableFunction<Tuple2<Record, Record>, Record> mp = new FlattenJoinResult();
+
+        final MapOperator<Tuple2<Record, Record>, Record> mapOperator = new MapOperator<Tuple2<Record, Record>, Record>(
+                mp,
+                ReflectionUtils.specify(Tuple2.class),
+                Record.class);
+
+        join.connectTo(0, mapOperator, 0);
+
+        return mapOperator;
+    }
+
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangRelConverter.java
@@ -54,6 +54,8 @@ public class WayangRelConverter {
             return new WayangProjectVisitor(this).visit((WayangProject) node);
         } else if (node instanceof WayangFilter) {
             return new WayangFilterVisitor(this).visit((WayangFilter) node);
+        } else if (node instanceof WayangJoin && WayangJoin.class.cast(node).getCondition().isAlwaysTrue()) {
+            return new WayangCrossJoinVisitor(this).visit((WayangJoin) node);
         } else if (node instanceof WayangJoin) {
             return new WayangJoinVisitor(this).visit((WayangJoin) node);
         } else if (node instanceof WayangAggregate) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FlattenJoinResult.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FlattenJoinResult.java
@@ -1,0 +1,31 @@
+package org.apache.wayang.api.sql.calcite.converter.functions;
+
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.core.function.FunctionDescriptor;
+
+/**
+ * Flattens the result of a join i.e. a {@link Tuple2} of a left and a right {@link Record} to a single {@link Record}.
+ */
+public class FlattenJoinResult implements FunctionDescriptor.SerializableFunction<Tuple2<Record, Record>, Record> {
+
+    @Override
+    public Record apply(final Tuple2<Record, Record> tuple2) {
+        final int length0 = tuple2.getField0().size();
+        final int length1 = tuple2.getField1().size();
+
+        final int totalLength = length0 + length1;
+
+        final Object[] fields = new Object[totalLength];
+
+        for (int i = 0; i < length0; i++) {
+            fields[i] = tuple2.getField0().getField(i);
+        }
+        
+        for (int i = length0; i < totalLength; i++) {
+            fields[i] = tuple2.getField1().getField(i - length0);
+        }
+
+        return new Record(fields);
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FlattenJoinResult.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FlattenJoinResult.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.wayang.api.sql.calcite.converter.functions;
 
 import org.apache.wayang.basic.data.Record;
@@ -5,7 +23,8 @@ import org.apache.wayang.basic.data.Tuple2;
 import org.apache.wayang.core.function.FunctionDescriptor;
 
 /**
- * Flattens the result of a join i.e. a {@link Tuple2} of a left and a right {@link Record} to a single {@link Record}.
+ * Flattens the result of a join i.e. a {@link Tuple2} of a left and a right
+ * {@link Record} to a single {@link Record}.
  */
 public class FlattenJoinResult implements FunctionDescriptor.SerializableFunction<Tuple2<Record, Record>, Record> {
 
@@ -21,7 +40,7 @@ public class FlattenJoinResult implements FunctionDescriptor.SerializableFunctio
         for (int i = 0; i < length0; i++) {
             fields[i] = tuple2.getField0().getField(i);
         }
-        
+
         for (int i = length0; i < totalLength; i++) {
             fields[i] = tuple2.getField1().getField(i - length0);
         }

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleSmallA.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleSmallA.csv
@@ -1,0 +1,3 @@
+COLA:string,COLB:string
+item1;item2
+item1;item2

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleSmallB.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleSmallB.csv
@@ -1,0 +1,4 @@
+COLA:string,COLB:string,COLC:string
+item1;item2;item3
+item1;item2;item3
+x;x;x


### PR DESCRIPTION
Added support & tests for cross joins / cartesian products in the sql-api, still missing an implementation for the ```JdbcExecutor```, so it just works for serialisation-based / java platforms.