### PR TITLE
Update Parquet operators to better use metadata early on

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/PlanBuilder.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/PlanBuilder.scala
@@ -24,7 +24,7 @@ package org.apache.wayang.api
 import org.apache.commons.lang3.Validate
 import org.apache.wayang.api
 import org.apache.wayang.basic.data.Record
-import org.apache.wayang.basic.operators.{CollectionSource, ObjectFileSource, TableSource, TextFileSource, ParquetSource, GoogleCloudStorageSource, AmazonS3Source, AzureBlobStorageSource}
+import org.apache.wayang.basic.operators.{AmazonS3Source, AzureBlobStorageSource, CollectionSource, GoogleCloudStorageSource, ObjectFileSource, ParquetSource, TableSource, TextFileSource}
 import org.apache.wayang.commons.util.profiledb.model.Experiment
 import org.apache.wayang.core.api.WayangContext
 import org.apache.wayang.core.plan.wayangplan._
@@ -122,6 +122,15 @@ class PlanBuilder(private[api] val wayangContext: WayangContext, private var job
     */
   def readTextFile(url: String): DataQuanta[String] = load(new TextFileSource(url))
 
+  /**
+   * Read a parquet file and provide it as a dataset of [[Record]]s.
+   *
+   * @param url the URL of the Parquet file
+   * @param projection the projection, if any
+   * @return [[DataQuanta]] of [[Record]]s representing the file
+   */
+  def readParquet(url: String, projection: Array[String]): RecordDataQuanta = load(ParquetSource.create(url, projection))
+
  /**
     * Read a text file from a Google Cloud Storage bucket and provide it as a dataset of [[String]]s, one per line.
     *
@@ -142,7 +151,6 @@ class PlanBuilder(private[api] val wayangContext: WayangContext, private var job
     */
   def readAmazonS3File(bucket: String, blobName: String, filePathToCredentialsFile: String ): DataQuanta[String] = load(new AmazonS3Source(bucket, blobName, filePathToCredentialsFile))
 
-
 /**
     * Read a text file from a Azure Blob Storage storage container and provide it as a dataset of [[String]]s, one per line.
     *
@@ -153,7 +161,6 @@ class PlanBuilder(private[api] val wayangContext: WayangContext, private var job
     */
   def readAzureBlobStorageFile(storageContainer: String, blobName: String, filePathToCredentialsFile: String ): DataQuanta[String] = load(new AzureBlobStorageSource(storageContainer, blobName, filePathToCredentialsFile))
 
-
   /**
     * Read a text file and provide it as a dataset of [[String]]s, one per line.
     *
@@ -161,7 +168,6 @@ class PlanBuilder(private[api] val wayangContext: WayangContext, private var job
     * @return [[DataQuanta]] representing the file
     */
   def readRemoteTextFile(url: String): DataQuanta[String] = load(new TextFileSource(url))
-
 
   /**
    * Read a object's file and provide it as a dataset of [[Object]]s.
@@ -178,14 +184,6 @@ class PlanBuilder(private[api] val wayangContext: WayangContext, private var job
     * @return [[DataQuanta]] of [[Record]]s in the table
     */
   def readTable(source: TableSource): DataQuanta[Record] = load(source)
-
-  /**
-   * Read a parquet file and provide it as a dataset of [[Record]]s.
-   *
-   * @param source from that the [[Record]]s should be read
-   * @return [[DataQuanta]] of [[Record]]s in the file
-   */
-  def readParquet(source: ParquetSource): DataQuanta[Record] = load(source)
 
   /**
     * Loads a [[java.util.Collection]] into Wayang and represents them as [[DataQuanta]].

--- a/wayang-benchmark/src/main/java/org/apache/wayang/apps/wordcount/WordCountParquet.java
+++ b/wayang-benchmark/src/main/java/org/apache/wayang/apps/wordcount/WordCountParquet.java
@@ -61,8 +61,7 @@ public class WordCountParquet {
         /* Start building the Apache WayangPlan */
         Collection<Tuple2<String, Integer>> wordcounts = planBuilder
                 /* Read the text file */
-                // .readParquet(new ParquetSource(args[1], new String[] { projectionColumns }, Arrays.copyOfRange(args, 2, args.length))) // In case of projection
-                .readParquet(new ParquetSource(args[1], null, Arrays.copyOfRange(args, 2, args.length)))
+                .readParquet(args[1], Arrays.copyOfRange(args, 2, args.length))
                 .withName("Load file")
 
                 /* Split each line by non-word characters */

--- a/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/mapping/ParquetSourceMapping.java
+++ b/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/mapping/ParquetSourceMapping.java
@@ -45,7 +45,7 @@ public class ParquetSourceMapping implements Mapping {
 
     private SubplanPattern createSubplanPattern() {
         final OperatorPattern operatorPattern = new OperatorPattern(
-                "source", new org.apache.wayang.basic.operators.ParquetSource((String) null, (String[]) null), false
+                "source", new ParquetSource((String) null, (String[]) null), false
         );
         return SubplanPattern.createSingleton(operatorPattern);
     }

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkParquetSource.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkParquetSource.java
@@ -20,8 +20,6 @@ package org.apache.wayang.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoder;
-import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.operators.ParquetSource;
@@ -43,8 +41,8 @@ import java.util.stream.IntStream;
  */
 public class SparkParquetSource extends ParquetSource implements SparkExecutionOperator {
 
-    public SparkParquetSource(String inputUrl, String[] projection, String... columnNames) {
-        super(inputUrl, projection, columnNames);
+    public SparkParquetSource(String inputUrl, String[] projection) {
+        super(inputUrl, projection);
     }
 
     /**


### PR DESCRIPTION
Users no longer need to provide the column names, they will be read by the operator itself.