### PR TITLE
fix a bug where tableA join tableB failed due to index sizes

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
@@ -67,8 +67,8 @@ public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
         // offset of the index in the right child
         final int offset = wayangRelNode.getInput(0).getRowType().getFieldCount();
 
-        final int leftKeyIndex = keys.get(0);
-        final int rightKeyIndex = keys.get(1) - offset;
+        final int leftKeyIndex = keys.get(0) < keys.get(1) ? keys.get(0) : keys.get(0) - offset;
+        final int rightKeyIndex = keys.get(0) < keys.get(1) ? keys.get(1) - offset : keys.get(1);
 
         final JoinOperator<Record, Record, Object> join = new JoinOperator<>(
                 new TransformationDescriptor<>(new JoinKeyExtractor(leftKeyIndex), Record.class, Object.class),


### PR DESCRIPTION
Due to the way we handle joins internally with the java key extractor i.e. over the input,
and how calcite handles joins i.e. a union type directly on the join. It was possible to get an out of bounds exception if you changed your sql join order from `tableA join tableB on tableA.col = tableB.col`  to `tableA join tableB on tableB.col = tableA.col`