### PR TITLE
fetch, offset & limit for java platforms in sql-api

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangSortVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangSortVisitor.java
@@ -24,7 +24,7 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.rex.RexNode;
+
 import org.apache.wayang.api.sql.calcite.converter.functions.SortFilter;
 import org.apache.wayang.api.sql.calcite.converter.functions.SortKeyExtractor;
 import org.apache.wayang.api.sql.calcite.rel.WayangSort;

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SortFilter.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SortFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.api.sql.calcite.converter.functions;
+
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.core.function.FunctionDescriptor;
+
+public class SortFilter implements FunctionDescriptor.SerializablePredicate<Record> {
+    final int offset;
+    final int fetch;
+    int increment;
+
+    /**
+     * The filter for a calcite/sql sort operator
+     * usually triggered by "LIMIT x", "OFFSET x", "FETCH x" statements
+     * @param offset amount of records ignored before accepting
+     * @param fetch amount of records accepted
+     */
+    public SortFilter(final int fetch, final int offset) {
+        this.fetch = fetch;
+        this.offset = offset;
+    }
+
+    @Override
+    public boolean test(final Record record) {
+        final boolean test = increment >= offset && increment <= fetch;
+        increment++;
+
+        return test;
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangSortRule.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rules/WayangSortRule.java
@@ -54,7 +54,7 @@ public class WayangSortRule extends ConverterRule {
                 sort.getHints(),
                 newInput,
                 sort.collation,
-                sort.fetch,
-                sort.offset);
+                sort.offset,
+                sort.fetch);
     }
 }

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -328,7 +328,7 @@ public class SqlToWayangRelTest {
                 assert (result.stream().anyMatch(rec -> rec.equals(new Record("test1", "test1", "test2"))));
         }
 
-        //@Test
+        @Test
         public void javaLimit() throws Exception {
                 final SqlContext sqlContext = createSqlContext("/data/exampleSort.csv");
 


### PR DESCRIPTION
I had to divide the Calcite sort into a Wayang sort operator and a filter operator to capture the fetch offset limit info. Any comments on this are welcome.