### PR TITLE
Use file based schema and named args for SqlContext main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <scala.mayor.version>2.12</scala.mayor.version>
         <spark.version>3.4.4</spark.version>
         <flink.version>1.20.0</flink.version>
-        <calcite.version>1.39.0</calcite.version>       
+        <calcite.version>1.39.0</calcite.version>
 
         <java.version>17</java.version>
         <source.level>17</source.level>
@@ -784,6 +784,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.3.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/wayang-api/pom.xml
+++ b/wayang-api/pom.xml
@@ -40,6 +40,7 @@
         <module>wayang-api-python</module>
         <module>wayang-api-sql</module>
         <module>wayang-api-json</module>
+        <module>wayang-api-utils</module>
     </modules>
 
 </project>

--- a/wayang-api/wayang-api-scala-java/pom.xml
+++ b/wayang-api/wayang-api-scala-java/pom.xml
@@ -106,6 +106,11 @@
           <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+          <groupId>org.apache.wayang</groupId>
+          <artifactId>wayang-tensorflow</artifactId>
+          <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
           <groupId>org.apache.spark</groupId>
           <artifactId>spark-core_2.12</artifactId>
           <version>${spark.version}</version>

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/Parameters.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/Parameters.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.api.util
+
+import org.apache.wayang.commons.util.profiledb.model.Experiment
+import org.apache.wayang.basic.WayangBasics
+import org.apache.wayang.core.optimizer.ProbabilisticDoubleInterval
+import org.apache.wayang.core.plugin.{DynamicPlugin, Plugin}
+import org.apache.wayang.java.Java
+import org.apache.wayang.tensorflow.Tensorflow
+import org.apache.wayang.postgres.Postgres
+import org.apache.wayang.spark.Spark
+import org.apache.wayang.sqlite3.Sqlite3
+
+/**
+  * Utility to parse parameters of the apps.
+  */
+object Parameters {
+
+  private val yamlId = """yaml\((.*)\)""".r
+
+  val yamlPluginHel = "yaml(<YAML plugin URL>)"
+
+  private val intPattern = """[+-]?\d+""".r
+
+  private val longPattern = """[+-]?\d+L""".r
+
+  private val doublePattern = """[+-]?\d+\.\d*""".r
+
+  private val booleanPattern = """(?:true)|(?:false)""".r
+
+  private val probabilisticDoubleIntervalPattern = """(\d+)\.\.(\d+)(~\d+.\d+)?""".r
+
+  private val experiment =
+    """exp\(([^,;]+)(?:;tags=([^,;]+(?:,[^,;]+)*))?(?:;conf=([^,;:]+:[^,;:]+(?:,[^,;:]+:[^,;:]+)*))?\)""".r
+
+  val experimentHelp = "exp(<ID>[,tags=<tag>,...][,conf=<key>:<value>,...])"
+
+  /**
+    * Load a plugin.
+    *
+    * @param id name of the plugin
+    * @return the loaded [[Plugin]]
+    */
+  def loadPlugin(id: String): Plugin = id match {
+    case "basic-graph" => WayangBasics.graphPlugin
+    case "java" => Java.basicPlugin
+    case "java-graph" => Java.graphPlugin
+    case "java-conversions" => Java.channelConversionPlugin
+    case "spark" => Spark.basicPlugin
+    case "spark-graph" => Spark.graphPlugin
+    case "spark-conversions" => Spark.conversionPlugin
+    case "postgres" => Postgres.plugin
+    case "postgres-conversions" => Postgres.conversionPlugin
+    case "sqlite3" => Sqlite3.plugin
+    case "sqlite3-conversions" => Sqlite3.conversionPlugin
+    case "tensorflow" => Tensorflow.plugin
+    case "tensorflow-conversions" => Tensorflow.channelConversionPlugin
+    case yamlId(url) => DynamicPlugin.loadYaml(url)
+    case other => throw new IllegalArgumentException(s"Could not load platform '$other'.")
+  }
+
+  /**
+    * Loads the specified [[Plugin]]s..
+    *
+    * @param platformIds a comma-separated list of platform IDs
+    * @return the loaded [[Plugin]]s
+    */
+  def loadPlugins(platformIds: String): Seq[Plugin] = loadPlugins(platformIds.split(","))
+
+  /**
+    * Loads the specified [[Plugin]]s.
+    *
+    * @param platformIds platform IDs
+    * @return the loaded [[Plugin]]s
+    */
+  def loadPlugins(platformIds: Seq[String]): Seq[Plugin] = platformIds.map(loadPlugin)
+
+
+  /**
+    * Parses a given [[String]] into a specific basic type.
+    *
+    * @param str the [[String]]
+    * @return the parsed value
+    */
+  def parseAny(str: String): AnyRef = {
+    str match {
+      case "null" => null
+      case intPattern() => java.lang.Integer.valueOf(str)
+      case longPattern() => java.lang.Long.valueOf(str.take(str.length - 1))
+      case doublePattern() => java.lang.Double.valueOf(str)
+      case booleanPattern() => java.lang.Boolean.valueOf(str)
+      case probabilisticDoubleIntervalPattern(lower, upper, conf) =>
+        new ProbabilisticDoubleInterval(lower.toDouble, upper.toDouble, if (conf == null) 1d else conf.substring(1).toDouble)
+      case other: String => other
+    }
+  }
+
+}

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -25,7 +25,7 @@
         <version>1.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    
+
     <artifactId>wayang-api-sql</artifactId>
     <dependencies>
         <dependency>
@@ -48,6 +48,11 @@
             <artifactId>wayang-core</artifactId>
             <version>1.0.1-SNAPSHOT</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-api-scala-java</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.wayang</groupId>

--- a/wayang-api/wayang-api-sql/pom.xml
+++ b/wayang-api/wayang-api-sql/pom.xml
@@ -51,8 +51,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.wayang</groupId>
-            <artifactId>wayang-api-scala-java</artifactId>
+            <artifactId>wayang-api-utils</artifactId>
             <version>1.0.1-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.wayang</groupId>

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -37,7 +37,7 @@ import org.apache.wayang.api.sql.calcite.utils.PrintUtils;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.plugin.Plugin;
-import org.apache.wayang.api.util.Parameters;
+import org.apache.wayang.api.utils.Parameters;
 import org.apache.wayang.core.api.WayangContext;
 import org.apache.wayang.core.util.ReflectionUtils;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
@@ -164,7 +164,7 @@ public class SqlContext extends WayangContext {
                 List.of(Java.channelConversionPlugin(), Postgres.conversionPlugin()));
 
         List<Plugin> plugins = JavaConversions.seqAsJavaList(Parameters.loadPlugins(cmd.getOptionValue("p")));
-        plugins.stream().forEach(plug -> context.register(plug));
+        plugins.stream().forEach(context::register);
 
         final Collection<Record> result = context.executeSql(query);
 

--- a/wayang-api/wayang-api-utils/pom.xml
+++ b/wayang-api/wayang-api-utils/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>wayang-api</artifactId>
+        <groupId>org.apache.wayang</groupId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wayang-api-utils</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+
+    <name>Wayang API Utils</name>
+    <description>Wayang implementation of an API of Scala-Java to be enable to work in functional style</description>
+
+    <properties>
+        <java-module-name>org.apache.wayang.api</java-module-name>
+        <tensorflow.version>1.0.0</tensorflow.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.wayang</groupId>
+                <artifactId>wayang-commons</artifactId>
+                <version>1.0.1-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-core</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-basic</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-utils-profile-db</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-api-python</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-java</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-sqlite3</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.wayang</groupId>
+            <artifactId>wayang-postgres</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.wayang</groupId>
+          <artifactId>wayang-spark</artifactId>
+          <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.wayang</groupId>
+          <artifactId>wayang-tensorflow</artifactId>
+          <version>1.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-core_2.12</artifactId>
+          <version>${spark.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-graphx_2.12</artifactId>
+          <version>${spark.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-mllib_2.12</artifactId>
+          <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+          <version>${scala.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+          <version>4.1.89.Final</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+          <version>3.25.5</version>
+        </dependency>
+         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.tensorflow</groupId>
+            <artifactId>tensorflow-core-platform</artifactId>
+            <version>${tensorflow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tensorflow</groupId>
+            <artifactId>tensorflow-framework</artifactId>
+            <version>${tensorflow.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wayang-api/wayang-api-utils/src/main/scala/Parameters.scala
+++ b/wayang-api/wayang-api-utils/src/main/scala/Parameters.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.wayang.api.util
+package org.apache.wayang.api.utils
 
 import org.apache.wayang.commons.util.profiledb.model.Experiment
 import org.apache.wayang.basic.WayangBasics


### PR DESCRIPTION
Changes proposed in this PR allow named arguments for executable main function in `SqlContext.java`:

```shell
./bin/wayang-submit org.apache.wayang.api.sql.context.SqlContext -p java,spark,postgres -jdbcDriver org.postgresql.Driver -jdbcUrl jdbc:postgresql://job:5432/job -jdbcPassword postgres -o /var/www/html/data/benchmarks/ -d /var/www/html/data/ -q /var/www/html/data/test.sql -c file:///var/www/html/conf/wayang-defaults.properties -s file:///var/www/html/wayang-api/wayang-api-sql/src/main/resources/model.json
```