### PR TITLE
Fix class cast exception in sql-api where clauses

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -18,7 +18,10 @@
 
 package org.apache.wayang.api.sql.calcite.converter.functions;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.SqlFunctions;
@@ -40,39 +43,39 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
         return (boolean) callTree.evaluate(record);
     }
 
-    class FilterCallTreeFactory implements CallTreeFactory <List<Object>, Object> {
+    class FilterCallTreeFactory implements CallTreeFactory<List<Object>, Object> {
         public SerializableFunction<List<Object>, Object> deriveOperation(final SqlKind kind) {
-            switch (kind) {
-                case NOT:
-                    return input -> !(boolean) input.get(0);
-                case IS_NOT_NULL:
-                    return input -> !isEqualTo(input.get(0), null);
-                case IS_NULL:
-                    return input -> isEqualTo(input.get(0), null);
-                case LIKE:
-                    return input -> like((String) input.get(0), (String) input.get(1));
-                case NOT_EQUALS:
-                    return input -> !isEqualTo(input.get(0), input.get(1));
-                case EQUALS:
-                    return input -> isEqualTo(input.get(0), input.get(1));
-                case GREATER_THAN:
-                    return input -> isGreaterThan(input.get(0), input.get(1));
-                case LESS_THAN:
-                    return input -> isLessThan(input.get(0), input.get(1));
-                case GREATER_THAN_OR_EQUAL:
-                    return input -> isGreaterThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
-                case LESS_THAN_OR_EQUAL:
-                    return input -> isLessThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
-                case AND:
-                    return input -> input.stream().map(Boolean.class::cast).allMatch(Boolean::booleanValue);
-                case OR:
-                    return input -> input.stream().map(Boolean.class::cast).anyMatch(Boolean::booleanValue);
-                default:
-                    throw new UnsupportedOperationException("Kind not supported: " + kind);
-            }
+            return (input) -> switch (kind) {
+                case NOT -> !(boolean) input.get(0);
+                case IS_NOT_NULL -> !isEqualTo(input.get(0), null);
+                case IS_NULL -> isEqualTo(input.get(0), null);
+                case LIKE -> like((String) input.get(0), (String) input.get(1));
+                case NOT_EQUALS -> !isEqualTo(input.get(0), input.get(1));
+                case EQUALS -> isEqualTo(input.get(0), input.get(1));
+                case GREATER_THAN -> isGreaterThan(input.get(0), input.get(1));
+                case LESS_THAN -> isLessThan(input.get(0), input.get(1));
+                case GREATER_THAN_OR_EQUAL ->
+                    isGreaterThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
+                case LESS_THAN_OR_EQUAL ->
+                    isLessThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
+                case AND -> input.stream().map(Boolean.class::cast).allMatch(Boolean::booleanValue);
+                case OR -> input.stream().map(Boolean.class::cast).anyMatch(Boolean::booleanValue);
+                default -> throw new UnsupportedOperationException("Kind not supported: " + kind);
+            };
         }
     }
 
+    /**
+     * Widening conversions
+     */
+    final SerializableFunction<Object, Comparable> ensureComparable = (a) -> a instanceof Integer val ? val.longValue() : (Comparable<?>) a;
+
+    /**
+     * Java equivalent of SQL like clauses
+     * @param s1
+     * @param s2
+     * @return true if {@code s1} like {@code s2}
+     */
     private boolean like(final String s1, final String s2) {
         final SqlFunctions.LikeFunction likeFunction = new SqlFunctions.LikeFunction();
         final boolean isMatch = likeFunction.like(s1, s2);
@@ -80,21 +83,33 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
         return isMatch;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    /**
+     * Java equivalent of sql greater than clauses
+     * @param o1
+     * @param o2
+     * @return true if {@code o1 > o2}
+     */
     private boolean isGreaterThan(final Object o1, final Object o2) {
-        assert (o1 instanceof Comparable);
-        return ((Comparable) o1).compareTo(o2) > 0;
+        return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) > 0;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    /**
+     * Java equivalent of sql less than clauses
+     * @param o1
+     * @param o2
+     * @return true if {@code o1 < o2}
+     */
     private boolean isLessThan(final Object o1, final Object o2) {
-        assert (o1 instanceof Comparable);
-        return ((Comparable) o1).compareTo(o2) < 0;
+        return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) < 0;
     }
 
-    @SuppressWarnings("rawtypes")
+    /**
+     * Java equivalent of SQL equals clauses
+     * @param o1
+     * @param o2
+     * @return true if {@code o1 == o2}
+     */
     private boolean isEqualTo(final Object o1, final Object o2) {
-        assert (o1 instanceof Comparable);
-        return ((Comparable) o1).equals(o2);
+        return ensureComparable.apply(o1).equals(ensureComparable.apply(o2));
     }
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -18,11 +18,7 @@
 
 package org.apache.wayang.api.sql.calcite.converter.functions;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.SqlKind;


### PR DESCRIPTION
If you had statements like column.id > 5, a class cast exception could happen if the column.id was of type long, while the literal 5 was of type int.