### PR TITLE
Add Python API for DecisionTreeRegression

### DIFF
--- a/python/src/pywy/basic/model/models.py
+++ b/python/src/pywy/basic/model/models.py
@@ -33,3 +33,11 @@ class LogisticRegression(Op):
         super().__init__(Op.DType.FLOAT32, name)
 
 
+class DecisionTreeRegression(Op):
+    def __init__(self, max_depth: int = 5, min_instances: int = 2, name=None):
+        super().__init__(Op.DType.FLOAT32, name)
+        self.max_depth = max_depth
+        self.min_instances = min_instances
+
+
+

--- a/python/src/pywy/dataquanta.py
+++ b/python/src/pywy/dataquanta.py
@@ -23,7 +23,7 @@ from pywy.types import (GenericTco, Predicate, Function, BiFunction, FlatmapFunc
 from pywy.operators import *
 from pywy.basic.data.record import Record
 from pywy.basic.model.option import Option
-from pywy.basic.model.models import (Model, LogisticRegression)
+from pywy.basic.model.models import (Model, LogisticRegression, DecisionTreeRegression)
 
 
 
@@ -201,6 +201,18 @@ class DataQuanta(GenericTco):
             fit_intercept: bool = True
     ) -> "DataQuanta[Out]":
         op = LogisticRegression()
+        self._connect(op, 0)
+        labels._connect(op, 1)
+        return DataQuanta(self.context, op)
+
+
+    def train_decision_tree_regression(
+            self: "DataQuanta[In]",
+            labels: "DataQuanta[In]",
+            max_depth: int = 5,
+            min_instances: int = 2
+    ) -> "DataQuanta[Out]":
+        op = DecisionTreeRegression(max_depth, min_instances)
         self._connect(op, 0)
         labels._connect(op, 1)
         return DataQuanta(self.context, op)

--- a/python/src/pywy/tests/test_decision_tree_regression.py
+++ b/python/src/pywy/tests/test_decision_tree_regression.py
@@ -1,0 +1,55 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import unittest
+from pywy.dataquanta import WayangContext
+from pywy.platforms.java import JavaPlugin
+from pywy.platforms.spark import SparkPlugin
+
+class TestTrainDecisionTreeRegression(unittest.TestCase):
+
+    def test_train_and_predict(self):
+        # Initialize context with platforms
+        ctx = WayangContext().register({JavaPlugin, SparkPlugin})
+
+        # Input features and labels
+        features = ctx.load_collection([
+            [1.0, 2.0],
+            [2.0, 3.0],
+            [3.0, 4.0],
+            [4.0, 5.0]
+        ])
+        labels = ctx.load_collection([3.0, 4.0, 5.0, 6.0])
+
+        # Train the model
+        model = features.train_decision_tree_regression(labels, max_depth=3, min_instances=1)
+
+        # Run predictions on same features
+        predictions = model.predict(features)
+
+        # Collect and validate
+        result = predictions.collect()
+        print("Predictions:", result)
+
+        self.assertEqual(len(result), 4)
+        for pred in result:
+            self.assertIsInstance(pred, float)
+            self.assertGreaterEqual(pred, 1.0)
+            self.assertLessEqual(pred, 7.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds support for training Decision Tree Regression models in the Python API.

- Added DecisionTreeRegression operator in models.py
- Added .train_decision_tree_regression() method to DataQuanta
- Includes a test that trains the model and validates predictions