### PR TITLE
Add LinearSVC Operator with Full API Support 

### DIFF
--- a/python/src/pywy/dataquanta.py
+++ b/python/src/pywy/dataquanta.py
@@ -23,7 +23,7 @@ from pywy.types import (GenericTco, Predicate, Function, BiFunction, FlatmapFunc
 from pywy.operators import *
 from pywy.basic.data.record import Record
 from pywy.basic.model.option import Option
-from pywy.basic.model.models import (Model, LogisticRegression, DecisionTreeRegression)
+from pywy.basic.model.models import (Model, LogisticRegression, DecisionTreeRegression, LinearSVC)
 
 
 
@@ -216,6 +216,18 @@ class DataQuanta(GenericTco):
         self._connect(op, 0)
         labels._connect(op, 1)
         return DataQuanta(self.context, op)
+
+    def train_linear_svc(
+            self: "DataQuanta[In]",
+            labels: "DataQuanta[In]",
+            max_iter: int = 10,
+            reg_param: float = 0.1
+    ) -> "DataQuanta[Out]":
+        op = LinearSVC(max_iter=max_iter, reg_param=reg_param)
+        self._connect(op, 0)
+        labels._connect(op, 1)
+        return DataQuanta(self.context, op)
+
 
 
     def store_textfile(self: "DataQuanta[In]", path: str, input_type: GenericTco = None) -> None:

--- a/python/src/pywy/tests/test_train_linear_svc.py
+++ b/python/src/pywy/tests/test_train_linear_svc.py
@@ -14,35 +14,29 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from pywy.basic.model.ops import Op
 
+import unittest
+from pywy.dataquanta import WayangContext
+from pywy.platforms.java import JavaPlugin
+from pywy.platforms.spark import SparkPlugin
 
-class Model:
-    pass
+class TestTrainLinearSVC(unittest.TestCase):
 
+    def test_train_and_predict(self):
+        ctx = WayangContext().register({JavaPlugin, SparkPlugin})
 
-class DLModel(Model):
-    def __init__(self, out: Op):
-        self.out = out
+        features = ctx.load_collection([[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+        labels = ctx.load_collection([1.0, 1.0, 0.0, 0.0])
 
-    def get_out(self):
-        return self.out
+        model = features.train_linear_svc(labels, max_iter=10, reg_param=0.1)
+        predictions = model.predict(features)
 
-class LogisticRegression(Op):
-    def __init__(self, name=None):
-        super().__init__(Op.DType.FLOAT32, name)
+        result = predictions.collect()
+        print("Predictions:", result)
 
+        self.assertEqual(len(result), 4)
+        for pred in result:
+            self.assertIn(pred, [0.0, 1.0])
 
-class DecisionTreeRegression(Op):
-    def __init__(self, max_depth: int = 5, min_instances: int = 2, name=None):
-        super().__init__(Op.DType.FLOAT32, name)
-        self.max_depth = max_depth
-        self.min_instances = min_instances
-
-
-class LinearSVC(Op):
-    def __init__(self, max_iter: int = 10, reg_param: float = 0.1, name=None):
-        super().__init__(Op.DType.FLOAT32, name)
-        self.max_iter = max_iter
-        self.reg_param = reg_param
-
+if __name__ == "__main__":
+    unittest.main()

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -140,6 +140,27 @@ class DataQuanta[Out: ClassTag](val operator: ElementaryOperator, outputIndex: I
     operator
   }
 
+  /**
+   * Feed this instance into a [[LinearSVCOperator]].
+   * Trains a linear support vector classification (SVM) model using feature vectors and label values.
+   *
+   * @param labels    DataQuanta containing the target binary labels (0.0 or 1.0)
+   * @param maxIter   the maximum number of iterations to optimize the linear SVM
+   * @param regParam  the regularization parameter (L2 penalty term)
+   * @return a new [[DataQuanta]] instance containing the trained [[SVMModel]]
+   */
+  def trainLinearSVC(
+                      labels: DataQuanta[java.lang.Double],
+                      maxIter: Int,
+                      regParam: Double
+                    ): DataQuanta[org.apache.wayang.basic.model.SVMModel] = {
+    val operator = new LinearSVCOperator(maxIter, regParam)
+    this.connectTo(operator, 0)
+    labels.connectTo(operator, 1)
+    operator
+  }
+
+
 
 
 

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuantaBuilder.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuantaBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.wayang.api.graph.{Edge, EdgeDataQuantaBuilder, EdgeDataQuantaB
 import org.apache.wayang.api.util.{DataQuantaBuilderCache, TypeTrap}
 import org.apache.wayang.basic.data.{Record, Tuple2 => RT2}
 import org.apache.wayang.basic.model.{DLModel, Model, LogisticRegressionModel,DecisionTreeRegressionModel}
-import org.apache.wayang.basic.operators.{DLTrainingOperator, GlobalReduceOperator, LocalCallbackSink, MapOperator, SampleOperator, LogisticRegressionOperator,DecisionTreeRegressionOperator}
+import org.apache.wayang.basic.operators.{DLTrainingOperator, GlobalReduceOperator, LocalCallbackSink, MapOperator, SampleOperator, LogisticRegressionOperator,DecisionTreeRegressionOperator, LinearSVCOperator}
 import org.apache.wayang.commons.util.profiledb.model.Experiment
 import org.apache.wayang.core.function.FunctionDescriptor.{SerializableBiFunction, SerializableBinaryOperator, SerializableFunction, SerializableIntUnaryOperator, SerializablePredicate}
 import org.apache.wayang.core.optimizer.ProbabilisticDoubleInterval
@@ -327,6 +327,29 @@ trait DataQuantaBuilder[+This <: DataQuantaBuilder[_, Out], Out] extends Logging
       this,
       that
     )
+
+  /**
+   * Feed the built [[DataQuanta]] of this and the given instance into a [[LinearSVCOperator]].
+   * This operator trains a linear support vector classification (SVM) model using input features and binary labels.
+   *
+   * @param that      the [[DataQuantaBuilder]] containing the label values
+   * @param maxIter   the maximum number of optimization iterations
+   * @param regParam  the regularization strength for the SVM model
+   * @return a [[DataQuantaBuilder]] containing the trained [[SVMModel]]
+   */
+  def trainLinearSVC(
+                      that: DataQuantaBuilder[_, java.lang.Double],
+                      maxIter: Int,
+                      regParam: Double
+                    ): DataQuantaBuilder[_, org.apache.wayang.basic.model.SVMModel] =
+    new CustomOperatorDataQuantaBuilder[org.apache.wayang.basic.model.SVMModel](
+      new LinearSVCOperator(maxIter, regParam),
+      0,
+      new DataQuantaBuilderCache,
+      this,
+      that
+    )
+
 
 
 

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/model/SVMModel.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/model/SVMModel.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.basic.model;
+
+
+public interface SVMModel extends Model {
+
+    /**
+     * Predict the label for a given input vector.
+     */
+    double predict(double[] features);
+}

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/operators/LinearSVCOperator.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/operators/LinearSVCOperator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.basic.operators;
+
+
+import org.apache.wayang.basic.model.SVMModel;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.optimizer.cardinality.CardinalityEstimator;
+import org.apache.wayang.core.plan.wayangplan.BinaryToUnaryOperator;
+import org.apache.wayang.core.types.DataSetType;
+
+import java.util.Optional;
+
+public class LinearSVCOperator extends BinaryToUnaryOperator<double[], Double, SVMModel> {
+
+    private final int maxIter;
+    private final double regParam;
+
+    public LinearSVCOperator(int maxIter, double regParam) {
+        super(
+                DataSetType.createDefaultUnchecked(double[].class),
+                DataSetType.createDefaultUnchecked(Double.class),
+                DataSetType.createDefaultUnchecked(SVMModel.class),
+                false
+        );
+        this.maxIter = maxIter;
+        this.regParam = regParam;
+    }
+
+    public LinearSVCOperator(LinearSVCOperator that) {
+        super(that);
+        this.maxIter = that.maxIter;
+        this.regParam = that.regParam;
+    }
+
+    public int getMaxIter() {
+        return maxIter;
+    }
+
+    public double getRegParam() {
+        return regParam;
+    }
+
+    @Override
+    public Optional<CardinalityEstimator> createCardinalityEstimator(int outputIndex, Configuration configuration) {
+        return super.createCardinalityEstimator(outputIndex, configuration);
+    }
+}

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/mapping/Mappings.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/mapping/Mappings.java
@@ -75,6 +75,7 @@ public class Mappings {
             new ModelTransformMapping(),
             new LogisticRegressionMapping(),
             new DecisionTreeRegressionMapping(),
+            new LinearSVCMapping(),
             new PredictMapping()
     );
 

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/mapping/ml/LinearSVCMapping.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/mapping/ml/LinearSVCMapping.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.spark.mapping.ml;
+
+
+import org.apache.wayang.basic.operators.LinearSVCOperator;
+import org.apache.wayang.core.mapping.*;
+import org.apache.wayang.spark.operators.ml.SparkLinearSVCOperator;
+import org.apache.wayang.spark.platform.SparkPlatform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link LinearSVCOperator} to {@link SparkLinearSVCOperator}.
+ */
+@SuppressWarnings("unchecked")
+public class LinearSVCMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                SparkPlatform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern operatorPattern = new OperatorPattern(
+                "linearSVC",
+                new LinearSVCOperator(10, 0.1),
+                false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<LinearSVCOperator>(
+                (matchedOperator, epoch) -> new SparkLinearSVCOperator(matchedOperator).at(epoch)
+        );
+    }
+}
+

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/ml/SparkLinearSVCOperator.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/ml/SparkLinearSVCOperator.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.wayang.spark.operators.ml;
+
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.ml.classification.LinearSVC;
+import org.apache.spark.ml.classification.LinearSVCModel;
+import org.apache.spark.ml.linalg.VectorUDT;
+import org.apache.spark.ml.linalg.Vectors;
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.apache.wayang.basic.operators.LinearSVCOperator;
+import org.apache.wayang.basic.model.SVMModel;
+import org.apache.wayang.core.optimizer.OptimizationContext;
+import org.apache.wayang.core.plan.wayangplan.ExecutionOperator;
+import org.apache.wayang.core.platform.ChannelDescriptor;
+import org.apache.wayang.core.platform.ChannelInstance;
+import org.apache.wayang.core.platform.lineage.ExecutionLineageNode;
+import org.apache.wayang.core.util.Tuple;
+import org.apache.wayang.basic.data.Tuple2;
+import org.apache.wayang.java.channels.CollectionChannel;
+import org.apache.wayang.spark.channels.RddChannel;
+import org.apache.wayang.spark.execution.SparkExecutor;
+import org.apache.wayang.spark.operators.SparkExecutionOperator;
+import org.apache.wayang.spark.model.SparkMLModel;
+
+import java.util.*;
+
+public class SparkLinearSVCOperator extends LinearSVCOperator implements SparkExecutionOperator {
+
+    private static final String FEATURES = "features";
+    private static final String LABEL = "label";
+
+    private static final StructType SCHEMA = new StructType(new StructField[]{
+            new StructField(FEATURES, new VectorUDT(), false, Metadata.empty()),
+            new StructField(LABEL, DataTypes.DoubleType, false, Metadata.empty())
+    });
+
+    public SparkLinearSVCOperator(int maxIter, double regParam) {
+        super(maxIter, regParam);
+    }
+
+    public SparkLinearSVCOperator(LinearSVCOperator that) {
+        super(that);
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        return Arrays.asList(RddChannel.UNCACHED_DESCRIPTOR, RddChannel.CACHED_DESCRIPTOR);
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        return Collections.singletonList(CollectionChannel.DESCRIPTOR);
+    }
+
+    @Override
+    public Tuple<Collection<ExecutionLineageNode>, Collection<ChannelInstance>> evaluate(
+            ChannelInstance[] inputs,
+            ChannelInstance[] outputs,
+            SparkExecutor sparkExecutor,
+            OptimizationContext.OperatorContext operatorContext) {
+
+        RddChannel.Instance featuresInput = (RddChannel.Instance) inputs[0];
+        RddChannel.Instance labelsInput = (RddChannel.Instance) inputs[1];
+        CollectionChannel.Instance output = (CollectionChannel.Instance) outputs[0];
+
+        JavaRDD<double[]> featuresRdd = featuresInput.provideRdd();
+        JavaRDD<Double> labelsRdd = labelsInput.provideRdd();
+
+        JavaRDD<Row> rows = featuresRdd.zip(labelsRdd).map(tuple ->
+                RowFactory.create(Vectors.dense(tuple._1), tuple._2)
+        );
+
+        Dataset<Row> trainingData = SparkSession.builder()
+                .getOrCreate()
+                .createDataFrame(rows, SCHEMA);
+
+        LinearSVC lsvc = new LinearSVC()
+                .setMaxIter(this.getMaxIter())
+                .setRegParam(this.getRegParam())
+                .setFeaturesCol(FEATURES)
+                .setLabelCol(LABEL);
+
+        LinearSVCModel sparkModel = lsvc.fit(trainingData);
+
+        output.accept(Collections.singletonList(new Model(sparkModel)));
+
+        return ExecutionOperator.modelLazyExecution(inputs, outputs, operatorContext);
+    }
+
+    @Override
+    public boolean containsAction() {
+        return false;
+    }
+
+    public static class Model implements SVMModel, SparkMLModel<double[], Double> {
+
+        private final LinearSVCModel model;
+
+        public Model(LinearSVCModel model) {
+            this.model = model;
+        }
+
+        @Override
+        public double predict(double[] features) {
+            return model.predict(Vectors.dense(features));
+        }
+
+        @Override
+        public JavaRDD<Double> predict(JavaRDD<double[]> input) {
+            JavaRDD<Row> rows = input.map(f -> RowFactory.create(Vectors.dense(f)));
+            StructType schema = new StructType(new StructField[]{
+                    new StructField(FEATURES, new VectorUDT(), false, Metadata.empty())
+            });
+            Dataset<Row> df = SparkSession.builder().getOrCreate().createDataFrame(rows, schema);
+            Dataset<Row> predictions = model.transform(df);
+            return predictions.select("prediction").toJavaRDD().map(row -> row.getDouble(0));
+        }
+
+        @Override
+        public JavaRDD<Tuple2<double[], Double>> transform(JavaRDD<double[]> input) {
+            JavaRDD<Row> rows = input.map(f -> RowFactory.create(Vectors.dense(f)));
+            StructType schema = new StructType(new StructField[]{
+                    new StructField(FEATURES, new VectorUDT(), false, Metadata.empty())
+            });
+            Dataset<Row> df = SparkSession.builder().getOrCreate().createDataFrame(rows, schema);
+            Dataset<Row> predictions = model.transform(df);
+            return predictions.toJavaRDD().map(row ->
+                    new Tuple2<>(((org.apache.spark.ml.linalg.Vector) row.getAs(FEATURES)).toArray(),
+                            row.getAs("prediction")));
+        }
+    }
+}

--- a/wayang-tests-integration/src/test/java/org/apache/wayang/tests/SparkIntegrationIT.java
+++ b/wayang-tests-integration/src/test/java/org/apache/wayang/tests/SparkIntegrationIT.java
@@ -23,6 +23,7 @@ import org.apache.wayang.basic.data.Tuple2;
 import org.apache.wayang.basic.operators.*;
 import org.apache.wayang.basic.model.LogisticRegressionModel;
 import org.apache.wayang.basic.model.DecisionTreeRegressionModel;
+import org.apache.wayang.basic.model.SVMModel;
 import org.apache.wayang.api.DataQuanta;
 import org.apache.wayang.api.JavaPlanBuilder;
 import org.apache.wayang.core.api.Configuration;
@@ -579,6 +580,38 @@ public class SparkIntegrationIT {
         for (double[] features : laggedFeatures) {
             double prediction = model.predict(features);
             assertTrue(prediction >= 1.0 && prediction <= 5.0);
+        }
+    }
+
+    @Test
+    public void testLinearSVCWithAPI() {
+        WayangContext context = new WayangContext()
+                .with(Spark.basicPlugin())
+                .with(Spark.mlPlugin());
+
+        JavaPlanBuilder planBuilder = new JavaPlanBuilder(context)
+                .withJobName("Linear SVC Test")
+                .withUdfJarOf(this.getClass());
+
+        List<double[]> features = Arrays.asList(
+                new double[]{0.0, 1.0},
+                new double[]{1.0, 0.0},
+                new double[]{1.0, 1.0},
+                new double[]{0.0, 0.0}
+        );
+        List<Double> labels = Arrays.asList(1.0, 1.0, 0.0, 0.0);
+
+        Collection<SVMModel> models = planBuilder
+                .loadCollection(features)
+                .trainLinearSVC(planBuilder.loadCollection(labels), 10, 0.1)
+                .collect();
+
+        assertEquals(1, models.size());
+        SVMModel model = models.iterator().next();
+
+        for (double[] f : features) {
+            double pred = model.predict(f);
+            assertTrue(pred == 0.0 || pred == 1.0);
         }
     }
 


### PR DESCRIPTION
This PR introduces a new LinearSVCOperator for training binary classification models using linear support vector machines (SVM) 

- LinearSVCOperator, SparkLinearSVCOperator, SVMModel interface
- LinearSVCMapping for Spark backend
- Integration test in SparkIntegrationIT.java
- .trainLinearSVC(...) added to DataQuanta and DataQuantaBuilder
- LinearSVC added in models.py
- .train_linear_svc(...) added to DataQuanta
- Test: test_train_linear_svc.py

