### PR TITLE
Custom delimiters for calcite json models in sql-api

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/schema/SchemaUtils.java
@@ -29,13 +29,16 @@ import java.sql.SQLException;
 
 public class SchemaUtils {
     public static CalciteSchema getSchema(Configuration configuration) throws SQLException {
-        String calciteModel = configuration.getStringProperty("wayang.calcite.model");
+        final String calciteModel = configuration.getStringProperty("wayang.calcite.model");
         final Connection connection = DriverManager.getConnection("jdbc:calcite:model=inline: "+calciteModel);
+
         return getCalciteSchema(connection);
     }
+
     public static CalciteSchema getCalciteSchema(Connection connection) throws SQLException {
-        CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+        final CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
         final SchemaPlus schemaPlus = calciteConnection.getRootSchema();
+
         return CalciteSchema.from(schemaPlus);
     }
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/ModelParser.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/utils/ModelParser.java
@@ -19,31 +19,40 @@
 package org.apache.wayang.api.sql.calcite.utils;
 
 import org.apache.wayang.core.api.Configuration;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Iterator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Iterator;
+import java.util.Objects;
+
+/* 
+ * TODO: investigate/convert to Calcite's SchemaPlus way of reading calcite models instead of manually handling JSON
+ */
 public class ModelParser {
-    private Configuration configuration;
-    private JSONObject json;
+    private final Configuration configuration;
+    private final JsonNode json;
 
     public ModelParser() throws IOException, ParseException {
-        Object obj = new JSONParser().parse(new FileReader("wayang-api/wayang-api-sql/src/main/resources/model.json"));
-        this.json = (JSONObject) obj;
+        final String jsonString = Files
+                .readString(new File("wayang-api/wayang-api-sql/src/main/resources/model.json").toPath());
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        this.json = objectMapper.readTree(jsonString);
+        this.configuration = null;
     }
 
-    public ModelParser(Configuration configuration) throws IOException, ParseException {
-        String calciteModel = "{\"calcite\"" + configuration.getStringProperty("wayang.calcite.model") + ",\"separator\":\";\"}";
+    public ModelParser(final Configuration configuration) throws IOException, ParseException {
+        final String calciteModel = "{\"calcite\":" + configuration.getStringProperty("wayang.calcite.model")
+                + ",\"separator\":\";\"}";
+        final ObjectMapper objectMapper = new ObjectMapper();
 
+        this.json = objectMapper.readTree(calciteModel);
         this.configuration = configuration;
-        Object obj = new JSONParser().parse(calciteModel);
-        this.json = (JSONObject) obj;
     }
 
     /**
@@ -58,69 +67,92 @@ public class ModelParser {
      * @throws ParseException If unable to parse the file at
      *                        {@code calciteModelPath}.
      */
-    public ModelParser(Configuration configuration, String calciteModelPath) throws IOException, ParseException {
+    public ModelParser(final Configuration configuration, final String calciteModelPath)
+            throws IOException, ParseException {
         this.configuration = configuration;
-        FileReader fr = new FileReader(calciteModelPath);
-        Object obj = new JSONParser().parse(fr);
+        final String calciteModel = Files.readString(new File(calciteModelPath).toPath());
+        final ObjectMapper objectMapper = new ObjectMapper();
 
-        this.json = (JSONObject) obj;
+        this.json = objectMapper.readTree(calciteModel);
     }
 
-     /**
+    /**
      * This method allows you to specify the Calcite path, useful for testing.
      * See also {@link #ModelParser(Configuration)} and {@link #ModelParser()}.
      *
-     * @param configuration    An empty configuration. Usage:
-     *                         {@code Configuration configuration = new ModelParser(new Configuration(), calciteModelPath).setProperties();}
-     * @param calciteModel    JSONized object of your calcite model
+     * @param configuration An empty configuration. Usage:
+     *                      {@code Configuration configuration = new ModelParser(new Configuration(), calciteModelPath).setProperties();}
+     * @param calciteModel  JSONized object of your calcite model
      * @throws IOException    If an I/O error occurs.
      * @throws ParseException If unable to parse the file at
      *                        {@code calciteModelPath}.
      */
-    public ModelParser(Configuration configuration, JSONObject calciteModel) throws IOException, ParseException {
+    public ModelParser(final Configuration configuration, final JsonNode calciteModel)
+            throws IOException, ParseException {
         this.configuration = configuration;
         this.json = calciteModel;
     }
 
-
     public Configuration setProperties() {
-        JSONObject calciteObj = (JSONObject) json.get("calcite");
-        String calciteModel = calciteObj.toString();
+        final JsonNode calciteObj = json.get("calcite");
+        final String calciteModel = calciteObj.toString();
+
         configuration.setProperty("wayang.calcite.model", calciteModel);
 
-        JSONArray schemas = (JSONArray) calciteObj.get("schemas");
+        final JsonNode schemas = calciteObj.get("schemas");
 
-        Iterator itr = schemas.iterator();
+        final Iterator<JsonNode> schemaIterator = schemas.iterator();
 
-        while (itr.hasNext()) {
-            JSONObject next = (JSONObject) itr.next();
-            if (next.get("name").equals("postgres")) {
-                JSONObject operand = (JSONObject) next.get("operand");
-                configuration.setProperty("wayang.postgres.jdbc.url", operand.get("jdbcUrl").toString());
-                configuration.setProperty("wayang.postgres.jdbc.user", operand.get("jdbcUser").toString());
-                configuration.setProperty("wayang.postgres.jdbc.password", operand.get("jdbcPassword").toString());
+        while (schemaIterator.hasNext()) {
+            final JsonNode next = schemaIterator.next();
+            if (next.get("name").asText().equals("postgres")) {
+                final JsonNode operand = next.get("operand");
+                configuration.setProperty("wayang.postgres.jdbc.url", operand.get("jdbcUrl").asText());
+                configuration.setProperty("wayang.postgres.jdbc.user", operand.get("jdbcUser").asText());
+                configuration.setProperty("wayang.postgres.jdbc.password", operand.get("jdbcPassword").asText());
             }
         }
         return configuration;
     }
 
     public String getFsPath() {
-        JSONObject calciteObj = (JSONObject) json.get("calcite");
-        JSONArray schemas = (JSONArray) calciteObj.get("schemas");
+        final JsonNode calciteObj = json.get("calcite");
+        final JsonNode schemas = calciteObj.get("schemas");
 
-        Iterator itr = schemas.iterator();
+        final Iterator<JsonNode> schemaIterator = schemas.iterator();
 
-        while (itr.hasNext()) {
-            JSONObject next = (JSONObject) itr.next();
-            if (next.get("name").equals("fs")) {
-                JSONObject operand = (JSONObject) next.get("operand");
-                return operand.get("directory").toString();
+        while (schemaIterator.hasNext()) {
+            final JsonNode next = schemaIterator.next();
+            if (next.get("name").asText().equals("fs")) {
+                final JsonNode operand = next.get("operand");
+
+                return operand.get("directory").asText();
             }
         }
         return null;
     }
 
-    public String getSeparator() {
-        return (String) json.get("separator");
+    /**
+     * Fetches the column delimiter character of the provided schema
+     * 
+     * @param schemaName name of the schema within the calcite model json object
+     * @return the delimiter as a char
+     */
+    public char getSchemaDelimiter(final String schemaName) {
+        final String jsonPath = "/calcite/schemas";
+        final JsonNode schemasNode = json.at(jsonPath);
+
+        if (schemasNode.isMissingNode())
+            throw new IllegalArgumentException("No \"schemas\" found in Calcite model JSON." + json.toPrettyString());
+        if (!schemasNode.isArray())
+            throw new IllegalArgumentException("\"schemas\" is not a JSON array." + json.toPrettyString());
+
+        for (final JsonNode schema : schemasNode) {
+            final String curSchemaName = schema.path("name").asText(null);
+            final String delimiter = schema.path("operand").path("delimiter").asText();
+            if (Objects.equals(schemaName, curSchemaName) && !delimiter.isEmpty()) return delimiter.charAt(0);
+        }
+
+        return ';';
     }
 }

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -665,7 +665,7 @@ class SqlToWayangRelTest {
         sqlContext.execute(wayangPlan);
 
         assertEquals(result.size(), 1);
-        assertEquals(result.stream().findFirst().get(), 3);
+        assertEquals(result.stream().findFirst().get().getInt(0), 3);
     }
 
     private SqlContext createSqlContext(final String tableResourceName)

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -49,10 +49,11 @@ import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 import org.apache.wayang.java.Java;
 import org.apache.wayang.spark.Spark;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -131,7 +132,8 @@ class SqlToWayangRelTest {
         final WayangPlan wayangPlan = t.field1;
 
         // except reduce by
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Java.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -148,7 +150,8 @@ class SqlToWayangRelTest {
         final WayangPlan wayangPlan = t.field1;
 
         // except reduce by
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Java.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -167,7 +170,8 @@ class SqlToWayangRelTest {
         final WayangPlan wayangPlan = t.field1;
 
         // except reduce by
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Java.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -185,7 +189,8 @@ class SqlToWayangRelTest {
         final WayangPlan wayangPlan = t.field1;
 
         // except reduce by
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Java.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -265,7 +270,8 @@ class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Java.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -456,7 +462,8 @@ class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Spark.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Spark.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -472,7 +479,8 @@ class SqlToWayangRelTest {
         final WayangPlan wayangPlan = t.field1;
 
         // except reduce by
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Spark.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Spark.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -493,7 +501,8 @@ class SqlToWayangRelTest {
         final Collection<Record> result = t.field0;
         final WayangPlan wayangPlan = t.field1;
 
-        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes().forEach(node -> node.addTargetPlatform(Spark.platform()));
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Spark.platform()));
 
         sqlContext.execute(wayangPlan);
 
@@ -543,7 +552,7 @@ class SqlToWayangRelTest {
         final ProjectMapFuncImpl deserializedImpl = (ProjectMapFuncImpl) inStream.readObject();
         inStream.close();
 
-        final Record testRecord = new Record(1,2,3);
+        final Record testRecord = new Record(1, 2, 3);
 
         assertEquals(impl.apply(testRecord), deserializedImpl.apply(testRecord));
     }
@@ -601,8 +610,8 @@ class SqlToWayangRelTest {
         assertEquals("AA", result.stream().findAny().orElseThrow().getString(0));
     }
 
-    private SqlContext createSqlContext(final String tableResourceName)
-            throws IOException, ParseException, SQLException {
+    @Test
+    void exampleCustomDelimiter() throws Exception {
         final String calciteModel = "{\r\n" + //
                 "    \"calcite\": {\r\n" + //
                 "      \"version\": \"1.0\",\r\n" + //
@@ -613,24 +622,80 @@ class SqlToWayangRelTest {
                 "          \"type\": \"custom\",\r\n" + //
                 "          \"factory\": \"org.apache.calcite.adapter.file.FileSchemaFactory\",\r\n" + //
                 "          \"operand\": {\r\n" + //
-                "            \"directory\": \"" + "/" + this.getClass().getResource("/data").getPath()
-                + "\"\r\n" + //
+                "            \"directory\": \"" + "/" + this.getClass().getResource("/data").getPath() + "\",\r\n" + //
+                "            \"delimiter\": \"|\"" +
                 "          }\r\n" + //
                 "        }\r\n" + //
                 "      ]\r\n" + //
-                "    },\r\n" + //
-                "    \"separator\": \";\"\r\n" + //
-                "  }\r\n" + //
-                "  \r\n" + //
-                "  \r\n";
+                "    }\r\n" + //
+                "  }";
 
-        final JSONObject calciteModelJSON = (JSONObject) new JSONParser().parse(calciteModel);
+        final JsonNode calciteModelJSON = new ObjectMapper().readTree(calciteModel);
+
         final Configuration configuration = new ModelParser(new Configuration(), calciteModelJSON)
                 .setProperties();
-        assertNotNull(configuration,"Could not get configuration with calcite model: " + calciteModel);
+        assertNotNull(configuration, "Could not get configuration with calcite model: " + calciteModel);
+
+        final String tableResourceName = "/data/exampleDelimiter.csv";
 
         final String dataPath = this.getClass().getResource(tableResourceName).getPath();
-        assertTrue(dataPath != null && !dataPath.isEmpty(), "Could not get table resource from path: " + tableResourceName);
+        assertTrue(dataPath != null && !dataPath.isEmpty(),
+                "Could not get table resource from path: " + tableResourceName);
+
+        configuration.setProperty("wayang.fs.table.url", dataPath);
+
+        configuration.setProperty(
+                "wayang.ml.executions.file",
+                "mle" + ".txt");
+
+        configuration.setProperty(
+                "wayang.ml.optimizations.file",
+                "mlo" + ".txt");
+
+        configuration.setProperty("wayang.ml.experience.enabled", "false");
+
+        final SqlContext sqlContext = new SqlContext(configuration);
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT count(*) FROM fs.exampleDelimiter" //
+        );
+
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        assertEquals(result.size(), 1);
+        assertEquals(result.stream().findFirst().get(), 3);
+    }
+
+    private SqlContext createSqlContext(final String tableResourceName)
+            throws IOException, ParseException, SQLException {
+        final String calciteModel = "{\r\n" +
+                "    \"calcite\": {\r\n" +
+                "      \"version\": \"1.0\",\r\n" +
+                "      \"defaultSchema\": \"wayang\",\r\n" +
+                "      \"schemas\": [\r\n" +
+                "        {\r\n" +
+                "          \"name\": \"fs\",\r\n" +
+                "          \"type\": \"custom\",\r\n" +
+                "          \"factory\": \"org.apache.calcite.adapter.file.FileSchemaFactory\",\r\n" +
+                "          \"operand\": {\r\n" +
+                "            \"directory\": \"" + "/" + this.getClass().getResource("/data").getPath() + "\"\r\n" +
+                "          }\r\n" +
+                "        }\r\n" +
+                "      ]\r\n" +
+                "    }\r\n" +
+                "  }";
+
+        final JsonNode calciteModelJSON = new ObjectMapper().readTree(calciteModel);
+
+        final Configuration configuration = new ModelParser(new Configuration(), calciteModelJSON)
+                .setProperties();
+        assertNotNull(configuration, "Could not get configuration with calcite model: " + calciteModel);
+
+        final String dataPath = this.getClass().getResource(tableResourceName).getPath();
+        assertTrue(dataPath != null && !dataPath.isEmpty(),
+                "Could not get table resource from path: " + tableResourceName);
 
         configuration.setProperty("wayang.fs.table.url", dataPath);
 

--- a/wayang-api/wayang-api-sql/src/test/resources/data/exampleDelimiter.csv
+++ b/wayang-api/wayang-api-sql/src/test/resources/data/exampleDelimiter.csv
@@ -1,0 +1,4 @@
+NAMEA:String,NAMEB:int,NAMEC:int
+test1|1|1
+|1|1
+test2|2|1


### PR DESCRIPTION
You should now be able to specify custom delimiters for your calcite models in the sql-api, like so:

```
{
  "calcite": {
    "version": "1.0",
    "defaultSchema": "wayang",
    "schemas": [
      {
        "name": "fs",
        "type": "custom",
        "factory": "org.apache.calcite.adapter.file.FileSchemaFactory",
        "operand": {
          "directory": "<data path>"
          "delimiter":"<custom delimiter>"
        }
      }
    ]
  }

```
With the key part being:
```
        "operand": {
          ...
          "delimiter":"<custom delimiter>"
          ...
        }
```