### PR TITLE
Better support for TPCH-like queries

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangFilterVisitor.java
@@ -18,7 +18,6 @@
 
 package org.apache.wayang.api.sql.calcite.converter;
 
-import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 
@@ -50,9 +49,18 @@ public class WayangFilterVisitor extends WayangRelNodeVisitor<WayangFilter> {
     }
 
     /** for quick sanity check **/
-    public static final EnumSet<SqlKind> SUPPORTED_OPS = EnumSet.of(SqlKind.AND, SqlKind.OR, SqlKind.NOT,
-            SqlKind.EQUALS, SqlKind.NOT_EQUALS,
-            SqlKind.LESS_THAN, SqlKind.GREATER_THAN,
-            SqlKind.GREATER_THAN_OR_EQUAL, SqlKind.LESS_THAN_OR_EQUAL, SqlKind.LIKE, SqlKind.IS_NOT_NULL, SqlKind.IS_NULL);
+    protected static final EnumSet<SqlKind> SUPPORTED_OPS = EnumSet.of(
+            SqlKind.AND,
+            SqlKind.OR,
+            SqlKind.NOT,
+            SqlKind.EQUALS,
+            SqlKind.NOT_EQUALS,
+            SqlKind.LESS_THAN,
+            SqlKind.GREATER_THAN,
+            SqlKind.GREATER_THAN_OR_EQUAL,
+            SqlKind.LESS_THAN_OR_EQUAL,
+            SqlKind.LIKE,
+            SqlKind.IS_NOT_NULL,
+            SqlKind.IS_NULL);
 
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/WayangJoinVisitor.java
@@ -19,7 +19,6 @@
 package org.apache.wayang.api.sql.calcite.converter;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
@@ -55,7 +54,7 @@ public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
         final List<Integer> keys = call.getOperands().stream()
             .map(RexInputRef.class::cast)
             .map(RexInputRef::getIndex)
-            .collect(Collectors.toList());
+            .toList();
 
         assert (keys.size() == 2) : "Amount of keys found in join was not 2, got: " + keys.size();
         
@@ -78,7 +77,7 @@ public class WayangJoinVisitor extends WayangRelNodeVisitor<WayangJoin> {
         childOpRight.connectTo(0, join, 1);
 
         // Join returns Tuple2 - map to a Record
-        final MapOperator<Tuple2<Record, Record>, Record> mapOperator = new MapOperator<Tuple2<Record, Record>, Record>(
+        final MapOperator<Tuple2<Record, Record>, Record> mapOperator = new MapOperator<>(
                 new JoinFlattenResult(),
                 ReflectionUtils.specify(Tuple2.class),
                 Record.class);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
@@ -87,11 +87,6 @@ class Literal implements Node {
     final Serializable value;
 
     Literal(final RexLiteral literal) {
-        System.out.println(literal.getValue().getClass());
-        System.out.println(literal.getValue2().getClass());
-        System.out.println(literal.getValue3().getClass());
-        System.out.println(literal.getValue4().getClass());
-
         value = switch (literal.getTypeName()) {
             case DATE         -> literal.getValueAs(Calendar.class);
             case INTEGER      -> literal.getValueAs(Double.class);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
@@ -30,8 +30,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.function.FunctionDescriptor.SerializableFunction;
 
-import com.amazonaws.services.kms.model.UnsupportedOperationException;
-
 /**
  * AST of the {@link RexCall} arithmetic, composed into serializable nodes;
  * {@link Call}, {@link InputRef}, {@link Literal}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -157,6 +157,8 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
             return character.toString();
         } else if (field instanceof final DateString dateString) {
             return (double) dateString.getMillisSinceEpoch();
+        } else if (field == null) {
+            return null;
         } else {
             throw new UnsupportedOperationException(
                     "Type not supported in filter comparisons yet: " + field.getClass());

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.NlsString;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.function.FunctionDescriptor;
 import org.apache.wayang.core.function.FunctionDescriptor.SerializableFunction;
@@ -156,7 +157,9 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
             return (double) calendar.getTime().getTime();
         } else if (field instanceof final String string) {
             return string;
-        } else if (field instanceof final Character character) {
+        } else if (field instanceof final NlsString nlsString) {
+            return nlsString.getValue();
+        }  else if (field instanceof final Character character) {
             return character.toString();
         } else if (field instanceof final DateString dateString) {
             return (double) dateString.getMillisSinceEpoch();

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.wayang.api.sql.calcite.converter.functions;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -32,18 +33,18 @@ import org.apache.wayang.core.function.FunctionDescriptor;
 import org.apache.wayang.core.function.FunctionDescriptor.SerializableFunction;
 
 public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredicate<Record> {
-    private final Node<Object> callTree;
+    private final Node callTree;
 
     public FilterPredicateImpl(final RexNode condition) {
         this.callTree = new FilterCallTreeFactory().fromRexNode(condition);
     }
 
     @Override
-    public boolean test(final Record record) {
-        return (boolean) callTree.evaluate(record);
+    public boolean test(final Record rec) {
+        return (boolean) callTree.evaluate(rec);
     }
 
-    class FilterCallTreeFactory implements CallTreeFactory<List<Object>, Object> {
+    class FilterCallTreeFactory implements CallTreeFactory {
         public SerializableFunction<List<Object>, Object> deriveOperation(final SqlKind kind) {
             return (input) -> switch (kind) {
                 case NOT -> !(boolean) input.get(0);
@@ -58,83 +59,93 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
                     isGreaterThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
                 case LESS_THAN_OR_EQUAL ->
                     isLessThan(input.get(0), input.get(1)) || isEqualTo(input.get(0), input.get(1));
-                case AND -> input.stream().map(Boolean.class::cast).allMatch(Boolean::booleanValue);
-                case OR -> input.stream().map(Boolean.class::cast).anyMatch(Boolean::booleanValue);
+                case AND -> input.stream().allMatch(obj -> Boolean.class.cast(obj).booleanValue());
+                case OR -> input.stream().anyMatch(obj -> Boolean.class.cast(obj).booleanValue());
                 case MINUS -> widenToDouble.apply(input.get(0)) - widenToDouble.apply(input.get(1));
                 case PLUS -> widenToDouble.apply(input.get(0)) + widenToDouble.apply(input.get(1));
                 default -> throw new UnsupportedOperationException("Kind not supported: " + kind);
             };
         }
+
+        /**
+         * Java equivalent of SQL like clauses
+         * 
+         * @param s1
+         * @param s2
+         * @return true if {@code s1} like {@code s2}
+         */
+        private boolean like(final String s1, final String s2) {
+            return new SqlFunctions.LikeFunction().like(s1, s2);
+        }
+
+        /**
+         * Java equivalent of sql greater than clauses
+         * 
+         * @param o1
+         * @param o2
+         * @return true if {@code o1 > o2}
+         */
+        private boolean isGreaterThan(final Object o1, final Object o2) {
+            return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) > 0;
+        }
+
+        /**
+         * Java equivalent of sql less than clauses
+         * 
+         * @param o1
+         * @param o2
+         * @return true if {@code o1 < o2}
+         */
+        private boolean isLessThan(final Object o1, final Object o2) {
+            return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) < 0;
+        }
+
+        /**
+         * Java equivalent of SQL equals clauses
+         * 
+         * @param o1
+         * @param o2
+         * @return true if {@code o1 == o2}
+         */
+        private boolean isEqualTo(final Object o1, final Object o2) {
+            return Objects.equals(ensureComparable.apply(o1), ensureComparable.apply(o2));
+        }
     }
 
     /**
-     * Widens number types to optional double 
-     * see also {@link #widenToDouble} 
-     * @return Optional.empty if no conversion available, Optional.of(double) otherwise
+     * Widens number types to optional double
+     * see also {@link #widenToDouble}
+     * 
+     * @return Optional.empty if no conversion available, Optional.of(double)
+     *         otherwise
      */
-    final SerializableFunction<Object, Optional<Double>> widenToOptionalDouble = 
-                field -> field instanceof final Number number ? Optional.of(number.doubleValue())    :
-                         field instanceof final Date date     ? Optional.of((double) date.getTime()) :  
-                         Optional.empty();
-    
+
+    final SerializableFunction<Object, Optional<Double>> widenToOptionalDouble = field -> {
+        if (field instanceof final Number number) {
+            return Optional.of(number.doubleValue());
+        } else if (field instanceof final Date date) {
+            return Optional.of((double) date.getTime());
+        } else if (field instanceof final Calendar calendar) {
+            return Optional.of((double) calendar.getTime().getTime());
+        } else {
+            return Optional.empty();
+        }
+    };
 
     /**
-     * Consumes the option from {@link #widenToOptionalDouble()}, and eagerly provides the underlying double.
+     * Consumes the option from {@link #widenToOptionalDouble()}, and eagerly
+     * provides the underlying double.
+     * 
      * @throws UnsupportedOperationException if conversion was not possible
      */
     final SerializableFunction<Object, Double> widenToDouble = field -> widenToOptionalDouble
-            .andThen(option -> option.orElseThrow(() -> new UnsupportedOperationException("Could not convert: " + option + " to double.")))
+            .andThen(option -> option.orElseThrow(() -> new UnsupportedOperationException(
+                    "Could not convert: " + option + " to double." + ", field: " + field)))
             .apply(field);
 
     /**
      * Widening conversions, all numbers to double
      */
-    final SerializableFunction<Object, Comparable> ensureComparable = field -> 
-        field instanceof Number || field instanceof Date ? widenToDouble.apply(field) : 
-        Comparable.class.cast(field);
-    
-
-    /**
-     * Java equivalent of SQL like clauses
-     * 
-     * @param s1
-     * @param s2
-     * @return true if {@code s1} like {@code s2}
-     */
-    private boolean like(final String s1, final String s2) {
-        return new SqlFunctions.LikeFunction().like(s1, s2);
-    }
-
-    /**
-     * Java equivalent of sql greater than clauses
-     * 
-     * @param o1
-     * @param o2
-     * @return true if {@code o1 > o2}
-     */
-    private boolean isGreaterThan(final Object o1, final Object o2) {
-        return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) > 0;
-    }
-
-    /**
-     * Java equivalent of sql less than clauses
-     * 
-     * @param o1
-     * @param o2
-     * @return true if {@code o1 < o2}
-     */
-    private boolean isLessThan(final Object o1, final Object o2) {
-        return ensureComparable.apply(o1).compareTo(ensureComparable.apply(o2)) < 0;
-    }
-
-    /**
-     * Java equivalent of SQL equals clauses
-     * 
-     * @param o1
-     * @param o2
-     * @return true if {@code o1 == o2}
-     */
-    private boolean isEqualTo(final Object o1, final Object o2) {
-        return Objects.equals(ensureComparable.apply(o1), ensureComparable.apply(o2));
-    }
+    final SerializableFunction<Object, Comparable> ensureComparable = field -> field instanceof Number
+            || field instanceof Date ? widenToDouble.apply(field) : Comparable.class.cast(field);
 }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -56,21 +56,24 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
                 case PLUS -> widenToDouble.apply(input.get(0)) + widenToDouble.apply(input.get(1));
                 case SEARCH -> {
                     if (input.get(0) instanceof final ImmutableRangeSet range) {
-                        assert input.get(1) instanceof Comparable : "field is not comparable: " + input.get(1).getClass();
-                        Comparable field = ensureComparable.apply(input.get(1));
-                        Comparable left = ensureComparable.apply(range.span().lowerEndpoint());
-                        Comparable right = ensureComparable.apply(range.span().upperEndpoint());
-                        Range<Comparable> newRange = Range.closed(left, right);
+                        assert input.get(1) instanceof Comparable
+                                : "field is not comparable: " + input.get(1).getClass();
+                        final Comparable field = ensureComparable.apply(input.get(1));
+                        final Comparable left = ensureComparable.apply(range.span().lowerEndpoint());
+                        final Comparable right = ensureComparable.apply(range.span().upperEndpoint());
+                        final Range<Comparable> newRange = Range.closed(left, right);
                         yield newRange.contains(field);
                     } else if (input.get(1) instanceof final ImmutableRangeSet range) {
-                        assert input.get(0) instanceof Comparable : "field is not comparable: " + input.get(0).getClass();
-                        Comparable field = ensureComparable.apply(input.get(0));
-                        Comparable left = ensureComparable.apply(range.span().lowerEndpoint());
-                        Comparable right = ensureComparable.apply(range.span().upperEndpoint());
-                        Range<Comparable> newRange = Range.closed(left, right);
+                        assert input.get(0) instanceof Comparable
+                                : "field is not comparable: " + input.get(0).getClass();
+                        final Comparable field = ensureComparable.apply(input.get(0));
+                        final Comparable left = ensureComparable.apply(range.span().lowerEndpoint());
+                        final Comparable right = ensureComparable.apply(range.span().upperEndpoint());
+                        final Range<Comparable> newRange = Range.closed(left, right);
                         yield newRange.contains(field);
                     } else {
-                        throw new UnsupportedOperationException("No range set found in SARG, input1: " + input.get(0).getClass() + ", input2: " + input.get(1).getClass());
+                        throw new UnsupportedOperationException("No range set found in SARG, input1: "
+                                + input.get(0).getClass() + ", input2: " + input.get(1).getClass());
                     }
                 }
                 default -> throw new UnsupportedOperationException("Kind not supported: " + kind);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -17,6 +17,10 @@
 
 package org.apache.wayang.api.sql.context;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -40,25 +44,16 @@ import org.apache.wayang.core.api.Configuration;
 import org.apache.wayang.core.plugin.Plugin;
 import org.apache.wayang.api.utils.Parameters;
 import org.apache.wayang.core.api.WayangContext;
-import org.apache.wayang.core.util.ReflectionUtils;
 import org.apache.wayang.core.plan.wayangplan.WayangPlan;
 import org.apache.wayang.java.Java;
 import org.apache.wayang.postgres.Postgres;
 import org.apache.wayang.spark.Spark;
-import org.apache.commons.cli.*;
-
-import com.google.common.io.Resources;
-
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 
 import scala.collection.JavaConversions;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.charset.Charset;
 import java.nio.file.Paths;
-import java.net.URL;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -177,8 +172,8 @@ public class SqlContext extends WayangContext {
         context.execute(getJobName(), wayangPlan);
 
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(outputPath))) {
-            for (final Record record : collector) {
-                writer.write(Arrays.toString(record.getValues()));
+            for (final Record rec : collector) {
+                writer.write(Arrays.toString(rec.getValues()));
                 writer.newLine();
             }
         } catch (final IOException e) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -24,6 +24,7 @@ import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.SubQueryRemoveRule;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.RuleSet;
@@ -151,8 +152,10 @@ public class SqlContext extends WayangContext {
         PrintUtils.print("After parsing sql query", relNode);
 
         final RuleSet rules = RuleSets.ofList(
+                SubQueryRemoveRule.Config.FILTER.toRule(),
+                SubQueryRemoveRule.Config.JOIN.toRule(),
+                SubQueryRemoveRule.Config.PROJECT.toRule(),
                 CoreRules.FILTER_INTO_JOIN,
-                CoreRules.JOIN_ASSOCIATE,
                 WayangRules.WAYANG_TABLESCAN_RULE,
                 WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
                 WayangRules.WAYANG_PROJECT_RULE,
@@ -198,6 +201,10 @@ public class SqlContext extends WayangContext {
         PrintUtils.print("After parsing sql query", relNode);
 
         final RuleSet rules = RuleSets.ofList(
+                SubQueryRemoveRule.Config.FILTER.toRule(),
+                SubQueryRemoveRule.Config.JOIN.toRule(),
+                SubQueryRemoveRule.Config.PROJECT.toRule(),
+                CoreRules.FILTER_INTO_JOIN,
                 WayangRules.WAYANG_TABLESCAN_RULE,
                 WayangRules.WAYANG_TABLESCAN_ENUMERABLE_RULE,
                 WayangRules.WAYANG_PROJECT_RULE,

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -323,6 +323,21 @@ class SqlToWayangRelTest {
     }
 
     @Test
+    void javaFilterWithAlgebra() throws Exception {
+        final SqlContext sqlContext = createSqlContext("/data/exampleInt.csv");
+
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.exampleInt WHERE exampleInt.NAMEC = 0 - 1 + 1" //
+        );
+
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+        sqlContext.execute(wayangPlan);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
     void filterWithLike() throws Exception {
         final SqlContext sqlContext = createSqlContext("/data/largeLeftTableIndex.csv");
 


### PR DESCRIPTION
We are still missing some features to completely handle TPC-H

- Tree algebra for projections & joins
Sometimes you can have nested statements in joins e.g. if you have =($x, or($y,$z)), we need to be able to unpack this.
- Sub-queries
for now I have added sub-query remove rule from Calcite, however this doesn't handle all sub-query cases, especially if the sub-query is nested


