### PR TITLE
Add explain syntax sugar to DataQuantaBuilder

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuantaBuilder.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuantaBuilder.scala
@@ -664,11 +664,19 @@ abstract class BasicDataQuantaBuilder[This <: DataQuantaBuilder[_, Out], Out](im
   }
 
   /**
+   * Syntax sugar to avoid calling build().explain() on [[DataQuantaBuilder]]
+   */
+  def explain(): Unit = {
+    this.dataQuanta().explain(false)
+  }
+
+  /**
     * Create the [[DataQuanta]] built by this instance. Note the configuration being done in [[dataQuanta()]].
     *
     * @return the created and partially configured [[DataQuanta]]
     */
   protected def build: DataQuanta[Out]
+
 
 }
 


### PR DESCRIPTION
This avoids the need to call

```scala
DataQuantaBuilder.build().explain()
```

and allows

```scala
DataQuantaBuilder.explain()
```

