### PR TITLE
more expressive tests for jdbcexecutor & sql-api

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/CallTreeFactory.java
@@ -58,14 +58,14 @@ interface CallTreeFactory extends Serializable {
      * @return a serializable function of +, -, * or /
      * @throws UnsupportedOperationException on unrecognized {@link SqlKind}
      */
-    public SerializableFunction<List<Object>, Object> deriveOperation(SqlKind kind);
+    public SerializableFunction<List<Object>, Object> deriveOperation(final SqlKind kind);
 }
 
 interface Node extends Serializable {
     public Object evaluate(final Record rec);
 }
 
-class Call implements Node {
+final class Call implements Node {
     private final List<Node> operands;
     final SerializableFunction<List<Object>, Object> operation;
 
@@ -83,7 +83,7 @@ class Call implements Node {
     }
 }
 
-class Literal implements Node {
+final class Literal implements Node {
     final Serializable value;
 
     Literal(final RexLiteral literal) {
@@ -109,7 +109,7 @@ class Literal implements Node {
     }
 }
 
-class InputRef implements Node {
+final class InputRef implements Node {
     private final int key;
 
     InputRef(final RexInputRef inputRef) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/optimizer/Optimizer.java
@@ -211,11 +211,11 @@ public class Optimizer {
         );
     }
 
-    public WayangPlan convert(RelNode relNode) {
+    public static WayangPlan convert(RelNode relNode) {
         return convert(relNode, new ArrayList<>());
     }
 
-    public WayangPlan convert(RelNode relNode, Collection<Record> collector) {
+    public static WayangPlan convert(RelNode relNode, Collection<Record> collector) {
 
         LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
 
@@ -225,8 +225,7 @@ public class Optimizer {
         return new WayangPlan(sink);
     }
 
-    public WayangPlan convertWithConfig(RelNode relNode, Configuration configuration, Collection<Record> collector) {
-
+    public static WayangPlan convertWithConfig(RelNode relNode, Configuration configuration, Collection<Record> collector) {
         LocalCallbackSink<Record> sink = LocalCallbackSink.createCollectingSink(collector, Record.class);
 
         Operator op = new WayangRelConverter(configuration).convert(relNode);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/rel/WayangTableScan.java
@@ -27,12 +27,12 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.schema.Table;
 import org.apache.wayang.api.sql.calcite.convention.WayangConvention;
-import org.apache.wayang.api.sql.calcite.utils.ModelParser;
 
 import java.util.List;
 
 public class WayangTableScan extends TableScan implements WayangRel {
 
+    //TODO: fields are never queried, why?
     private final int[] fields;
 
     public WayangTableScan(RelOptCluster cluster,
@@ -83,11 +83,15 @@ public class WayangTableScan extends TableScan implements WayangRel {
     }
 
     public String getQualifiedName() {
-        return table.getQualifiedName().get(1);
+        return table.getQualifiedName().size() == 1 
+            ? table.getQualifiedName().get(0) 
+            : table.getQualifiedName().get(1);
     }
 
     public String getTableName() {
-        return table.getQualifiedName().get(1);
+        return table.getQualifiedName().size() == 1 
+            ? table.getQualifiedName().get(0) 
+            : table.getQualifiedName().get(1);
     }
 
     public List<String> getColumnNames() {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/context/SqlContext.java
@@ -167,7 +167,7 @@ public class SqlContext extends WayangContext {
         PrintUtils.print("After translating logical intermediate plan", wayangRel);
 
         final Collection<Record> collector = new ArrayList<>();
-        final WayangPlan wayangPlan = optimizer.convertWithConfig(wayangRel, configuration, collector);
+        final WayangPlan wayangPlan = Optimizer.convertWithConfig(wayangRel, configuration, collector);
         collector.add(new Record(wayangRel.getRowType().getFieldNames().toArray()));
         context.execute(getJobName(), wayangPlan);
 
@@ -182,7 +182,6 @@ public class SqlContext extends WayangContext {
     }
 
     public Collection<Record> executeSql(final String sql) throws SqlParseException {
-
         final Properties configProperties = Optimizer.ConfigProperties.getDefaults();
         final RelDataTypeFactory relDataTypeFactory = new JavaTypeFactoryImpl();
 
@@ -216,7 +215,7 @@ public class SqlContext extends WayangContext {
         PrintUtils.print("After translating logical intermediate plan", wayangRel);
 
         final Collection<Record> collector = new ArrayList<>();
-        final WayangPlan wayangPlan = optimizer.convert(wayangRel, collector);
+        final WayangPlan wayangPlan = Optimizer.convert(wayangRel, collector);
 
         this.execute(getJobName(), wayangPlan);
 

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/function/ProjectionDescriptor.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/function/ProjectionDescriptor.java
@@ -18,140 +18,42 @@
 
 package org.apache.wayang.basic.function;
 
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.types.RecordType;
 import org.apache.wayang.core.function.FunctionDescriptor;
 import org.apache.wayang.core.function.TransformationDescriptor;
 import org.apache.wayang.core.types.BasicDataUnitType;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 /**
- * This descriptor pertains to projections. It takes field names of the input type to describe the projection.
+ * This descriptor pertains to projections. It takes field names of the input
+ * type to describe the projection.
  */
 public class ProjectionDescriptor<Input, Output> extends TransformationDescriptor<Input, Output> {
-
-    private List<String> fieldNames;
-
-    /**
-     * Creates a new instance.
-     *
-     * @param inputTypeClass  input type
-     * @param outputTypeClass output type
-     * @param fieldNames      names of the fields to be projected
-     */
-    public ProjectionDescriptor(Class<Input> inputTypeClass,
-                                Class<Output> outputTypeClass,
-                                String... fieldNames) {
-        this(BasicDataUnitType.createBasic(inputTypeClass),
-                BasicDataUnitType.createBasic(outputTypeClass),
-                fieldNames);
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param inputType  input type
-     * @param outputType output type
-     * @param fieldNames names of the fields to be projected
-     */
-    public ProjectionDescriptor(BasicDataUnitType<Input> inputType, BasicDataUnitType<Output> outputType, String... fieldNames) {
-        this(createPojoJavaImplementation(fieldNames, inputType),
-                Collections.unmodifiableList(Arrays.asList(fieldNames)),
-                inputType,
-                outputType);
-    }
-
-    /**
-     * Basic constructor.
-     *
-     * @param javaImplementation Java-based implementation of the projection
-     * @param fieldNames         names of the fields to be projected
-     * @param inputType          input {@link BasicDataUnitType}
-     * @param outputType         output {@link BasicDataUnitType}
-     */
-    private ProjectionDescriptor(SerializableFunction<Input, Output> javaImplementation,
-                                 List<String> fieldNames,
-                                 BasicDataUnitType<Input> inputType,
-                                 BasicDataUnitType<Output> outputType) {
-        super(javaImplementation, inputType, outputType);
-        this.fieldNames = fieldNames;
-    }
-
-    /**
-     * Creates a new instance that specifically projects {@link Record}s.
-     *
-     * @param inputType  input {@link RecordType}
-     * @param fieldNames names of fields to be projected
-     * @return the new instance
-     */
-    public static ProjectionDescriptor<Record, Record> createForRecords(RecordType inputType, String... fieldNames) {
-        final SerializableFunction<Record, Record> javaImplementation = createRecordJavaImplementation(fieldNames, inputType);
-        return new ProjectionDescriptor<>(
-                javaImplementation,
-                Arrays.asList(fieldNames),
-                inputType,
-                new RecordType(fieldNames)
-        );
-    }
-
-    private static <Input, Output> FunctionDescriptor.SerializableFunction<Input, Output>
-    createPojoJavaImplementation(String[] fieldNames, BasicDataUnitType<Input> inputType) {
-        // Get the names of the fields to be projected.
-        if (fieldNames.length != 1) {
-            return t -> {
-                throw new IllegalStateException("The projection descriptor currently supports only a single field.");
-            };
-        }
-        String fieldName = fieldNames[0];
-        return new PojoImplementation<>(fieldName);
-    }
-
-    private static FunctionDescriptor.SerializableFunction<Record, Record>
-    createRecordJavaImplementation(String[] fieldNames, RecordType inputType) {
-        return new RecordImplementation(inputType, fieldNames);
-    }
-
-    /**
-     * Transforms an array of {@link RecordType} field names to indices.
-     *
-     * @param recordType that maps field names to indices
-     * @param fieldNames the field names
-     * @return the field indices
-     */
-    private static int[] toIndices(RecordType recordType, String[] fieldNames) {
-        int[] fieldIndices = new int[fieldNames.length];
-        for (int i = 0; i < fieldNames.length; i++) {
-            String fieldName = fieldNames[i];
-            fieldIndices[i] = recordType.getIndex(fieldName);
-        }
-        return fieldIndices;
-    }
-
-    public List<String> getFieldNames() {
-        return this.fieldNames;
-    }
 
     /**
      * Java implementation of a projection on POJOs via reflection.
      */
-    // TODO: Revise implementation to support multiple field projection, by names and indexes.
-    private static class PojoImplementation<Input, Output> implements FunctionDescriptor.SerializableFunction<Input, Output> {
+    // TODO: Revise implementation to support multiple field projection, by names
+    // and indexes.
+    private static class PojoImplementation<Input, Output>
+            implements FunctionDescriptor.SerializableFunction<Input, Output> {
 
         private final String fieldName;
 
         private Field field;
 
-        private PojoImplementation(String fieldName) {
+        private PojoImplementation(final String fieldName) {
             this.fieldName = fieldName;
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public Output apply(Input input) {
+        public Output apply(final Input input) {
             // Initialization code.
             if (this.field == null) {
 
@@ -161,7 +63,7 @@ public class ProjectionDescriptor<Input, Output> extends TransformationDescripto
                 // Find the projection field via reflection.
                 try {
                     this.field = typeClass.getField(this.fieldName);
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     throw new IllegalStateException("The configuration of the projection seems to be illegal.", e);
                 }
             }
@@ -169,7 +71,7 @@ public class ProjectionDescriptor<Input, Output> extends TransformationDescripto
             // Actual function.
             try {
                 return (Output) this.field.get(input);
-            } catch (IllegalAccessException e) {
+            } catch (final IllegalAccessException e) {
                 throw new RuntimeException("Illegal projection function.", e);
             }
         }
@@ -191,19 +93,121 @@ public class ProjectionDescriptor<Input, Output> extends TransformationDescripto
          * @param recordType {@link RecordType} of input {@link Record}s
          * @param fieldNames that should be projected on
          */
-        private RecordImplementation(RecordType recordType, String... fieldNames) {
+        private RecordImplementation(final RecordType recordType, final String... fieldNames) {
             this.fieldIndices = toIndices(recordType, fieldNames);
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public Record apply(Record input) {
-            Object[] projectedFields = new Object[this.fieldIndices.length];
+        public Record apply(final Record input) {
+            final Object[] projectedFields = new Object[this.fieldIndices.length];
             for (int i = 0; i < this.fieldIndices.length; i++) {
-                int fieldIndex = this.fieldIndices[i];
+                final int fieldIndex = this.fieldIndices[i];
                 projectedFields[i] = input.getField(fieldIndex);
             }
             return new Record(projectedFields);
         }
+    }
+
+    /**
+     * Creates a new instance that specifically projects {@link Record}s.
+     *
+     * @param inputType  input {@link RecordType}
+     * @param fieldNames names of fields to be projected
+     * @return the new instance
+     */
+    public static ProjectionDescriptor<Record, Record> createForRecords(final RecordType inputType, final String... fieldNames) {
+        final SerializableFunction<Record, Record> javaImplementation = createRecordJavaImplementation(fieldNames,
+                inputType);
+        return new ProjectionDescriptor<>(
+                javaImplementation,
+                Arrays.asList(fieldNames),
+                inputType,
+                new RecordType(fieldNames));
+    }
+
+    private static <Input, Output> FunctionDescriptor.SerializableFunction<Input, Output> createPojoJavaImplementation(
+            final String[] fieldNames, final BasicDataUnitType<Input> inputType) {
+        // Get the names of the fields to be projected.
+        if (fieldNames.length != 1) {
+            return t -> {
+                throw new IllegalStateException("The projection descriptor currently supports only a single field.");
+            };
+        }
+        final String fieldName = fieldNames[0];
+        return new PojoImplementation<>(fieldName);
+    }
+
+    private static FunctionDescriptor.SerializableFunction<Record, Record> createRecordJavaImplementation(
+            final String[] fieldNames, final RecordType inputType) {
+        return new RecordImplementation(inputType, fieldNames);
+    }
+
+    /**
+     * Transforms an array of {@link RecordType} field names to indices.
+     *
+     * @param recordType that maps field names to indices
+     * @param fieldNames the field names
+     * @return the field indices
+     */
+    private static int[] toIndices(final RecordType recordType, final String[] fieldNames) {
+        final int[] fieldIndices = new int[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; i++) {
+            final String fieldName = fieldNames[i];
+            fieldIndices[i] = recordType.getIndex(fieldName);
+        }
+        return fieldIndices;
+    }
+
+    private final List<String> fieldNames;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param inputTypeClass  input type
+     * @param outputTypeClass output type
+     * @param fieldNames      names of the fields to be projected
+     */
+    public ProjectionDescriptor(final Class<Input> inputTypeClass,
+            final Class<Output> outputTypeClass,
+            final String... fieldNames) {
+        this(BasicDataUnitType.createBasic(inputTypeClass),
+                BasicDataUnitType.createBasic(outputTypeClass),
+                fieldNames);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param inputType  input type
+     * @param outputType output type
+     * @param fieldNames names of the fields to be projected
+     */
+    public ProjectionDescriptor(final BasicDataUnitType<Input> inputType, final BasicDataUnitType<Output> outputType,
+            final String... fieldNames) {
+        this(createPojoJavaImplementation(fieldNames, inputType),
+                Collections.unmodifiableList(Arrays.asList(fieldNames)),
+                inputType,
+                outputType);
+    }
+
+    /**
+     * Basic constructor.
+     *
+     * @param javaImplementation Java-based implementation of the projection
+     * @param fieldNames         names of the fields to be projected
+     * @param inputType          input {@link BasicDataUnitType}
+     * @param outputType         output {@link BasicDataUnitType}
+     */
+    public ProjectionDescriptor(final SerializableFunction<Input, Output> javaImplementation,
+            final List<String> fieldNames,
+            final BasicDataUnitType<Input> inputType,
+            final BasicDataUnitType<Output> outputType) {
+        super(javaImplementation, inputType, outputType);
+        this.fieldNames = fieldNames;
+    }
+
+    public List<String> getFieldNames() {
+        return this.fieldNames;
     }
 }

--- a/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/ProjectionMapping.java
+++ b/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/ProjectionMapping.java
@@ -34,10 +34,8 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * /**
  * Mapping from {@link MapOperator} to {@link PostgresProjectionOperator}.
  */
-@SuppressWarnings("unchecked")
 public class ProjectionMapping implements Mapping {
 
     @Override
@@ -45,8 +43,7 @@ public class ProjectionMapping implements Mapping {
         return Collections.singleton(new PlanTransformation(
                 this.createSubplanPattern(),
                 this.createReplacementSubplanFactory(),
-                PostgresPlatform.getInstance()
-        ));
+                PostgresPlatform.getInstance()));
     }
 
     private SubplanPattern createSubplanPattern() {
@@ -55,10 +52,8 @@ public class ProjectionMapping implements Mapping {
                 new MapOperator<>(
                         null,
                         DataSetType.createDefault(Record.class),
-                        DataSetType.createDefault(Record.class)
-                ),
-                false
-        )
+                        DataSetType.createDefault(Record.class)),
+                false)
                 .withAdditionalTest(op -> op.getFunctionDescriptor() instanceof ProjectionDescriptor)
                 .withAdditionalTest(op -> op.getNumInputs() == 1); // No broadcasts.
         return SubplanPattern.createSingleton(operatorPattern);
@@ -66,7 +61,6 @@ public class ProjectionMapping implements Mapping {
 
     private ReplacementSubplanFactory createReplacementSubplanFactory() {
         return new ReplacementSubplanFactory.OfSingleOperators<MapOperator<Record, Record>>(
-                (matchedOperator, epoch) -> new PostgresProjectionOperator(matchedOperator).at(epoch)
-        );
+                (matchedOperator, epoch) -> new PostgresProjectionOperator(matchedOperator).at(epoch));
     }
 }


### PR DESCRIPTION
I split the functionality of `JdbcExecutor` to allow for easier testing, and write a simple test for Jdbc mappings with the sql-api.

One issue I've noted is that `createSqlClause()` method for operators require Jdbc connection & function compilers despite never actually being used? We need to revisit the architecture of how we convert `JdbcOperator`s to the underlying sql string.