### PR TITLE
Modified REST server in JSON-REST API

### DIFF
--- a/wayang-api/wayang-api-json/src/main/scala/Main.scala
+++ b/wayang-api/wayang-api-json/src/main/scala/Main.scala
@@ -62,10 +62,10 @@ object Main extends ZIOAppDefault {
         }
         resBody <- ZIO.succeed(Response.text(responseBody))
      } yield resBody).catchAll(t => {
-      // Error printed in server
+      // Error messages printed in server
       t.printStackTrace
 
-      // Error sent to client
+      // Error messages sent to client
       val stringWriter = new StringWriter()
       val printWriter = new PrintWriter(stringWriter)
       t.printStackTrace(printWriter)


### PR DESCRIPTION
Changed the REST server (Main.scala) in JSON-REST API to also return the error message back to client when an execution error occur. Only status code are returned originally.

This is for agentic setups to be able to debug generated JSON Wayang plans.