### PR TITLE
Fix JOIN clause to reference the correct table in SQL query generation

### DIFF
--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcJoinOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcJoinOperator.java
@@ -73,7 +73,7 @@ public abstract class JdbcJoinOperator<KeyType>
         final String rightTableName = right.field0;
         final String rightKey = right.field1;
 
-        return "JOIN " + leftTableName + " ON " +
+        return "JOIN " + rightTableName + " ON " +
             rightTableName + "." + rightKey
             + "=" + leftTableName + "." + leftKey;
     }

--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/JdbcJoinOperatorTest.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/JdbcJoinOperatorTest.java
@@ -119,7 +119,7 @@ class JdbcJoinOperatorTest extends OperatorTestBase {
         System.out.println();
 
         assertEquals(
-            "SELECT * FROM testA JOIN testA ON testB.a=testA.a;",
+            "SELECT * FROM testA JOIN testB ON testB.a=testA.a;",
             sqlQueryChannelInstance.getSqlQuery()
         );
     }


### PR DESCRIPTION

* Corrected the SQL JOIN clause in `JdbcJoinOperator#createSqlClause` to use the right table name when forming the JOIN statement, ensuring the SQL query generated is not a self-join.


* Updated the expected SQL query in `JdbcJoinOperatorTest#testWithHsqldb` to match the corrected JOIN clause logic.