### PR TITLE
Revert "Update .asf.yaml"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,13 +16,23 @@
 #
 
 github:
-  description: Building An Industrial Federated Learning Framework
-  homepage: https://wayang.apache.org/
+  description: Apache Wayang(incubating) is the first cross-platform data processing system.
+  homepage: https://wayang.incubator.apache.org/
   labels:
-    - machine learning
-    - algorithm
-    - privacy-preserving
-    - federated-learning
+    - big-data 
+    - apache
+    - data-management-platform
+    - java
+    - scala
+    - cross-platform
+    - data-processing
+    - hadoop
+    - spark
+    - jdbc
+    - open-source
+    - middleware
+    - performance
+    - distributed-system
   features:
     # Disable wiki for documentation
     wiki: false


### PR DESCRIPTION
Reverts apache/wayang#487 
Please revert the title and keep the rest of the labels as they were. We can still have federated-learning as label but not in the title, at least not yet