### PR TITLE
Add TableSink operator with Java/Spark implementations

### DIFF
--- a/wayang-commons/wayang-basic/pom.xml
+++ b/wayang-commons/wayang-basic/pom.xml
@@ -121,11 +121,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-core</artifactId>
-            <version>${calcite.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
         </dependency>

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/operators/TableSink.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/operators/TableSink.java
@@ -52,8 +52,11 @@ public class TableSink<T> extends UnarySink<T> {
     public TableSink(Properties props, String mode, String tableName, String[] columnNames, DataSetType<T> type) {
         super(type);
         this.tableName = tableName;
-        this.columnNames = columnNames;
-        this.props = props;
+        this.columnNames = columnNames == null ? null : java.util.Arrays.copyOf(columnNames, columnNames.length);
+        this.props = new Properties();
+        if (props != null) {
+            this.props.putAll(props);
+        }
         this.mode = mode;
     }
 
@@ -75,15 +78,17 @@ public class TableSink<T> extends UnarySink<T> {
     }
 
     protected void setColumnNames(String[] columnNames) {
-        this.columnNames = columnNames;
+        this.columnNames = columnNames == null ? null : java.util.Arrays.copyOf(columnNames, columnNames.length);
     }
 
     public String[] getColumnNames() {
-        return this.columnNames;
+        return this.columnNames == null ? null : java.util.Arrays.copyOf(this.columnNames, this.columnNames.length);
     }
 
     public Properties getProperties() {
-        return this.props;
+        Properties copy = new Properties();
+        copy.putAll(this.props);
+        return copy;
     }
 
     public String getMode() {

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/DatabaseProduct.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/DatabaseProduct.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.basic.util;
+
+/**
+ * Internal representation of database products to avoid external dependencies
+ * in wayang-basic.
+ */
+public enum DatabaseProduct {
+    POSTGRESQL,
+    MYSQL,
+    ORACLE,
+    SQLITE,
+    H2,
+    DERBY,
+    MSSQL,
+    UNKNOWN
+}

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
@@ -18,10 +18,7 @@
 
 package org.apache.wayang.basic.util;
 
-import org.apache.calcite.sql.SqlDialect;
 import org.apache.wayang.basic.data.Record;
-
-import java.lang.reflect.Field;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -36,7 +33,7 @@ import java.util.Map;
  */
 public class SqlTypeUtils {
 
-    private static final Map<SqlDialect.DatabaseProduct, Map<Class<?>, String>> dialectTypeMaps = new HashMap<>();
+    private static final Map<DatabaseProduct, Map<Class<?>, String>> dialectTypeMaps = new HashMap<>();
 
     static {
         // Default mappings (Standard SQL)
@@ -57,13 +54,13 @@ public class SqlTypeUtils {
         defaultMap.put(Timestamp.class, "TIMESTAMP");
         defaultMap.put(LocalDateTime.class, "TIMESTAMP");
 
-        dialectTypeMaps.put(SqlDialect.DatabaseProduct.UNKNOWN, defaultMap);
+        dialectTypeMaps.put(DatabaseProduct.UNKNOWN, defaultMap);
 
         // PostgreSQL Overrides
         Map<Class<?>, String> pgMap = new HashMap<>(defaultMap);
         pgMap.put(Double.class, "DOUBLE PRECISION");
         pgMap.put(double.class, "DOUBLE PRECISION");
-        dialectTypeMaps.put(SqlDialect.DatabaseProduct.POSTGRESQL, pgMap);
+        dialectTypeMaps.put(DatabaseProduct.POSTGRESQL, pgMap);
 
         // Add more dialects here as needed (MySQL, Oracle, etc.)
     }
@@ -74,30 +71,26 @@ public class SqlTypeUtils {
      * @param url JDBC URL
      * @return detected DatabaseProduct
      */
-    public static SqlDialect.DatabaseProduct detectProduct(String url) {
+    public static DatabaseProduct detectProduct(String url) {
         if (url == null)
-            return SqlDialect.DatabaseProduct.UNKNOWN;
+            return DatabaseProduct.UNKNOWN;
         String lowerUrl = url.toLowerCase();
         if (lowerUrl.contains("postgresql") || lowerUrl.contains("postgres"))
-            return SqlDialect.DatabaseProduct.POSTGRESQL;
+            return DatabaseProduct.POSTGRESQL;
         if (lowerUrl.contains("mysql"))
-            return SqlDialect.DatabaseProduct.MYSQL;
+            return DatabaseProduct.MYSQL;
         if (lowerUrl.contains("oracle"))
-            return SqlDialect.DatabaseProduct.ORACLE;
+            return DatabaseProduct.ORACLE;
         if (lowerUrl.contains("sqlite")) {
-            try {
-                return SqlDialect.DatabaseProduct.valueOf("SQLITE");
-            } catch (Exception e) {
-                return SqlDialect.DatabaseProduct.UNKNOWN;
-            }
+            return DatabaseProduct.SQLITE;
         }
         if (lowerUrl.contains("h2"))
-            return SqlDialect.DatabaseProduct.H2;
+            return DatabaseProduct.H2;
         if (lowerUrl.contains("derby"))
-            return SqlDialect.DatabaseProduct.DERBY;
+            return DatabaseProduct.DERBY;
         if (lowerUrl.contains("mssql") || lowerUrl.contains("sqlserver"))
-            return SqlDialect.DatabaseProduct.MSSQL;
-        return SqlDialect.DatabaseProduct.UNKNOWN;
+            return DatabaseProduct.MSSQL;
+        return DatabaseProduct.UNKNOWN;
     }
 
     /**
@@ -107,9 +100,9 @@ public class SqlTypeUtils {
      * @param product database product
      * @return SQL type string
      */
-    public static String getSqlType(Class<?> cls, SqlDialect.DatabaseProduct product) {
+    public static String getSqlType(Class<?> cls, DatabaseProduct product) {
         Map<Class<?>, String> typeMap = dialectTypeMaps.getOrDefault(product,
-                dialectTypeMaps.get(SqlDialect.DatabaseProduct.UNKNOWN));
+                dialectTypeMaps.get(DatabaseProduct.UNKNOWN));
         return typeMap.getOrDefault(cls, "VARCHAR(255)");
     }
 
@@ -120,7 +113,7 @@ public class SqlTypeUtils {
      * @param product database product
      * @return a list of schema fields
      */
-    public static List<SchemaField> getSchema(Class<?> cls, SqlDialect.DatabaseProduct product) {
+    public static List<SchemaField> getSchema(Class<?> cls, DatabaseProduct product) {
         List<SchemaField> schema = new ArrayList<>();
         if (cls == Record.class) {
             // For Record.class without an instance, we can't derive names/types easily
@@ -128,12 +121,29 @@ public class SqlTypeUtils {
             return schema;
         }
 
-        for (Field field : cls.getDeclaredFields()) {
-            if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+        for (java.lang.reflect.Method method : cls.getMethods()) {
+            if (java.lang.reflect.Modifier.isStatic(method.getModifiers()) ||
+                    method.getParameterCount() > 0 ||
+                    method.getReturnType() == void.class ||
+                    method.getName().equals("getClass")) {
                 continue;
             }
-            schema.add(new SchemaField(field.getName(), field.getType(), getSqlType(field.getType(), product)));
+
+            String name = method.getName();
+            String propertyName = null;
+            if (name.startsWith("get") && name.length() > 3) {
+                propertyName = Character.toLowerCase(name.charAt(3)) + name.substring(4);
+            } else if (name.startsWith("is") && name.length() > 2
+                    && (method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class)) {
+                propertyName = Character.toLowerCase(name.charAt(2)) + name.substring(3);
+            }
+
+            if (propertyName != null) {
+                schema.add(new SchemaField(propertyName, method.getReturnType(),
+                        getSqlType(method.getReturnType(), product)));
+            }
         }
+        schema.sort(java.util.Comparator.comparing(SchemaField::getName));
         return schema;
     }
 
@@ -145,7 +155,7 @@ public class SqlTypeUtils {
      * @param userNames optional user-provided column names
      * @return a list of schema fields
      */
-    public static List<SchemaField> getSchema(Record record, SqlDialect.DatabaseProduct product, String[] userNames) {
+    public static List<SchemaField> getSchema(Record record, DatabaseProduct product, String[] userNames) {
         List<SchemaField> schema = new ArrayList<>();
         if (record == null)
             return schema;

--- a/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/util/SqlTypeUtilsTest.java
+++ b/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/util/SqlTypeUtilsTest.java
@@ -18,12 +18,9 @@
 
 package org.apache.wayang.basic.util;
 
-import org.apache.calcite.sql.SqlDialect;
 import org.apache.wayang.basic.data.Record;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,60 +29,68 @@ public class SqlTypeUtilsTest {
 
     @Test
     public void testDetectProduct() {
-        assertEquals(SqlDialect.DatabaseProduct.POSTGRESQL,
+        assertEquals(DatabaseProduct.POSTGRESQL,
                 SqlTypeUtils.detectProduct("jdbc:postgresql://localhost:5432/db"));
-        assertEquals(SqlDialect.DatabaseProduct.MYSQL, SqlTypeUtils.detectProduct("jdbc:mysql://localhost:3306/db"));
-        assertEquals(SqlDialect.DatabaseProduct.ORACLE,
+        assertEquals(DatabaseProduct.MYSQL,
+                SqlTypeUtils.detectProduct("jdbc:mysql://localhost:3306/db"));
+        assertEquals(DatabaseProduct.ORACLE,
                 SqlTypeUtils.detectProduct("jdbc:oracle:thin:@localhost:1521:xe"));
-        assertEquals(SqlDialect.DatabaseProduct.H2, SqlTypeUtils.detectProduct("jdbc:h2:mem:test"));
-        assertEquals(SqlDialect.DatabaseProduct.DERBY,
+        assertEquals(DatabaseProduct.SQLITE,
+                SqlTypeUtils.detectProduct("jdbc:sqlite:test.db"));
+        assertEquals(DatabaseProduct.H2,
+                SqlTypeUtils.detectProduct("jdbc:h2:mem:test"));
+        assertEquals(DatabaseProduct.DERBY,
                 SqlTypeUtils.detectProduct("jdbc:derby:memory:test;create=true"));
-        assertEquals(SqlDialect.DatabaseProduct.MSSQL,
+        assertEquals(DatabaseProduct.MSSQL,
                 SqlTypeUtils.detectProduct("jdbc:sqlserver://localhost:1433;databaseName=db"));
-        assertEquals(SqlDialect.DatabaseProduct.UNKNOWN, SqlTypeUtils.detectProduct("jdbc:unknown:db"));
+        assertEquals(DatabaseProduct.UNKNOWN, SqlTypeUtils.detectProduct("jdbc:unknown:db"));
     }
 
     @Test
     public void testGetSqlTypeDefault() {
-        SqlDialect.DatabaseProduct product = SqlDialect.DatabaseProduct.UNKNOWN;
-        assertEquals("INT", SqlTypeUtils.getSqlType(Integer.class, product));
-        assertEquals("INT", SqlTypeUtils.getSqlType(int.class, product));
-        assertEquals("BIGINT", SqlTypeUtils.getSqlType(Long.class, product));
-        assertEquals("DOUBLE", SqlTypeUtils.getSqlType(Double.class, product));
-        assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, product));
-        assertEquals("DATE", SqlTypeUtils.getSqlType(Date.class, product));
-        assertEquals("TIMESTAMP", SqlTypeUtils.getSqlType(Timestamp.class, product));
+        assertEquals("INT", SqlTypeUtils.getSqlType(Integer.class, DatabaseProduct.UNKNOWN));
+        assertEquals("INT", SqlTypeUtils.getSqlType(int.class, DatabaseProduct.UNKNOWN));
+        assertEquals("BIGINT", SqlTypeUtils.getSqlType(Long.class, DatabaseProduct.UNKNOWN));
+        assertEquals("DOUBLE", SqlTypeUtils.getSqlType(Double.class, DatabaseProduct.UNKNOWN));
+        assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, DatabaseProduct.UNKNOWN));
+        assertEquals("DATE", SqlTypeUtils.getSqlType(java.sql.Date.class, DatabaseProduct.UNKNOWN));
+        assertEquals("TIMESTAMP", SqlTypeUtils.getSqlType(java.sql.Timestamp.class, DatabaseProduct.UNKNOWN));
     }
 
     @Test
-    public void testGetSqlTypePostgres() {
-        SqlDialect.DatabaseProduct product = SqlDialect.DatabaseProduct.POSTGRESQL;
-        assertEquals("INT", SqlTypeUtils.getSqlType(Integer.class, product));
-        assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(Double.class, product));
-        assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(double.class, product));
-        assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, product));
+    public void testPostgresqlOverrides() {
+        assertEquals("INT", SqlTypeUtils.getSqlType(Integer.class, DatabaseProduct.POSTGRESQL));
+        assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(Double.class, DatabaseProduct.POSTGRESQL));
+        assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(double.class, DatabaseProduct.POSTGRESQL));
+        assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, DatabaseProduct.POSTGRESQL));
     }
 
     @Test
     public void testGetSchema() {
         List<SqlTypeUtils.SchemaField> schema = SqlTypeUtils.getSchema(TestPojo.class,
-                SqlDialect.DatabaseProduct.POSTGRESQL);
-        assertEquals(3, schema.size());
+                DatabaseProduct.POSTGRESQL);
+        // id, name, value, active (from getter/is)
+        assertEquals(4, schema.size());
 
-        assertEquals("id", schema.get(0).getName());
-        assertEquals("INT", schema.get(0).getSqlType());
+        schema.sort((f1, f2) -> f1.getName().compareTo(f2.getName()));
 
-        assertEquals("name", schema.get(1).getName());
-        assertEquals("VARCHAR(255)", schema.get(1).getSqlType());
+        assertEquals("active", schema.get(0).getName());
+        assertEquals("BOOLEAN", schema.get(0).getSqlType());
 
-        assertEquals("value", schema.get(2).getName());
-        assertEquals("DOUBLE PRECISION", schema.get(2).getSqlType());
+        assertEquals("id", schema.get(1).getName());
+        assertEquals("INT", schema.get(1).getSqlType());
+
+        assertEquals("name", schema.get(2).getName());
+        assertEquals("VARCHAR(255)", schema.get(2).getSqlType());
+
+        assertEquals("value", schema.get(3).getName());
+        assertEquals("DOUBLE PRECISION", schema.get(3).getSqlType());
     }
 
     @Test
     public void testGetSchemaRecord() {
         Record record = new Record(1, "test", 1.5);
-        List<SqlTypeUtils.SchemaField> schema = SqlTypeUtils.getSchema(record, SqlDialect.DatabaseProduct.POSTGRESQL,
+        List<SqlTypeUtils.SchemaField> schema = SqlTypeUtils.getSchema(record, DatabaseProduct.POSTGRESQL,
                 null);
 
         assertEquals(3, schema.size());
@@ -106,7 +111,7 @@ public class SqlTypeUtilsTest {
     public void testGetSchemaRecordWithNames() {
         Record record = new Record(1, "test");
         String[] names = { "id", "description" };
-        List<SqlTypeUtils.SchemaField> schema = SqlTypeUtils.getSchema(record, SqlDialect.DatabaseProduct.POSTGRESQL,
+        List<SqlTypeUtils.SchemaField> schema = SqlTypeUtils.getSchema(record, DatabaseProduct.POSTGRESQL,
                 names);
 
         assertEquals(2, schema.size());
@@ -115,8 +120,26 @@ public class SqlTypeUtilsTest {
     }
 
     public static class TestPojo {
-        public int id;
-        public String name;
-        public Double value;
+        private int id;
+        private String name;
+        private Double value;
+        private boolean active;
+        private String hidden;
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Double getValue() {
+            return value;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
     }
 }

--- a/wayang-platforms/wayang-java/pom.xml
+++ b/wayang-platforms/wayang-java/pom.xml
@@ -78,12 +78,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.20.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
-            <scope>test</scope>
-        </dependency>
         <!-- Mockito for mocking -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/operators/JavaTableSink.java
+++ b/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/operators/JavaTableSink.java
@@ -20,6 +20,7 @@ package org.apache.wayang.java.operators;
 
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.basic.util.DatabaseProduct;
 import org.apache.wayang.basic.util.SqlTypeUtils;
 import org.apache.wayang.core.optimizer.OptimizationContext;
 import org.apache.wayang.core.plan.wayangplan.ExecutionOperator;
@@ -97,20 +98,26 @@ public class JavaTableSink<T> extends TableSink<T> implements JavaExecutionOpera
         assert outputs.length == 0;
         JavaChannelInstance input = (JavaChannelInstance) inputs[0];
 
-        // The stream is converted to an Iterator so that we can read the first element
-        // w/o consuming the entire stream.
         Iterator<T> recordIterator = input.<T>provideStream().iterator();
 
         if (!recordIterator.hasNext()) {
             return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
         }
 
-        // We read the first element to derive the Record schema.
         T firstElement = recordIterator.next();
         Class<?> typeClass = this.getType().getDataUnitType().getTypeClass();
 
+        if (typeClass == Record.class && this.getColumnNames() != null) {
+            Record r = (Record) firstElement;
+            if (r.size() < this.getColumnNames().length) {
+                throw new org.apache.wayang.core.api.exception.WayangException(
+                        String.format("Record length (%d) is less than expected column count (%d)",
+                                r.size(), this.getColumnNames().length));
+            }
+        }
+
         String url = this.getProperties().getProperty("url");
-        org.apache.calcite.sql.SqlDialect.DatabaseProduct product = SqlTypeUtils.detectProduct(url);
+        DatabaseProduct product = SqlTypeUtils.detectProduct(url);
 
         List<SqlTypeUtils.SchemaField> schemaFields;
         if (typeClass != Record.class) {
@@ -130,7 +137,7 @@ public class JavaTableSink<T> extends TableSink<T> implements JavaExecutionOpera
 
         String[] sqlTypes = new String[currentColumnNames.length];
         for (int i = 0; i < currentColumnNames.length; i++) {
-            sqlTypes[i] = "VARCHAR(255)"; // Default
+            sqlTypes[i] = "VARCHAR(255)";
             for (SqlTypeUtils.SchemaField field : schemaFields) {
                 if (field.getName().equals(currentColumnNames[i])) {
                     sqlTypes[i] = field.getSqlType();
@@ -142,72 +149,80 @@ public class JavaTableSink<T> extends TableSink<T> implements JavaExecutionOpera
         final String[] finalColumnNames = currentColumnNames;
         final String[] finalSqlTypes = sqlTypes;
 
-        this.getProperties().setProperty("streamingBatchInsert", "True");
+        Properties writeProps = this.getProperties();
+        writeProps.setProperty("streamingBatchInsert", "True");
 
-        Connection conn;
         try {
-            Class.forName(this.getProperties().getProperty("driver"));
-            conn = DriverManager.getConnection(this.getProperties().getProperty("url"), this.getProperties());
-            conn.setAutoCommit(false);
+            Class.forName(writeProps.getProperty("driver"));
+            String quote = (product == DatabaseProduct.MYSQL) ? "`"
+                    : (product == DatabaseProduct.MSSQL) ? "[" : "\"";
+            String closingQuote = (product == DatabaseProduct.MSSQL) ? "]" : quote;
 
-            Statement stmt = conn.createStatement();
+            try (Connection conn = DriverManager.getConnection(writeProps.getProperty("url"), writeProps)) {
+                conn.setAutoCommit(false);
+                try (Statement stmt = conn.createStatement()) {
+                    if (this.getMode().equals("overwrite")) {
+                        stmt.execute("DROP TABLE IF EXISTS " + quote + this.getTableName() + closingQuote);
+                    }
 
-            // Drop existing table if the mode is 'overwrite'.
-            if (this.getMode().equals("overwrite")) {
-                stmt.execute("DROP TABLE IF EXISTS " + this.getTableName());
-            }
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("CREATE TABLE IF NOT EXISTS ").append(quote).append(this.getTableName())
+                            .append(closingQuote).append(" (");
+                    String separator = "";
+                    for (int i = 0; i < finalColumnNames.length; i++) {
+                        sb.append(separator).append(quote).append(finalColumnNames[i]).append(closingQuote).append(" ")
+                                .append(finalSqlTypes[i]);
+                        separator = ", ";
+                    }
+                    sb.append(")");
+                    stmt.execute(sb.toString());
 
-            // Create a new table if the specified table name does not exist yet.
-            StringBuilder sb = new StringBuilder();
-            sb.append("CREATE TABLE IF NOT EXISTS ").append(this.getTableName()).append(" (");
-            String separator = "";
-            for (int i = 0; i < finalColumnNames.length; i++) {
-                sb.append(separator).append("\"").append(finalColumnNames[i]).append("\" ").append(finalSqlTypes[i]);
-                separator = ", ";
-            }
-            sb.append(")");
-            stmt.execute(sb.toString());
+                    sb = new StringBuilder();
+                    sb.append("INSERT INTO ").append(quote).append(this.getTableName()).append(closingQuote)
+                            .append(" (");
+                    separator = "";
+                    for (int i = 0; i < finalColumnNames.length; i++) {
+                        sb.append(separator).append(quote).append(finalColumnNames[i]).append(closingQuote);
+                        separator = ", ";
+                    }
+                    sb.append(") VALUES (");
+                    separator = "";
+                    for (int i = 0; i < finalColumnNames.length; i++) {
+                        sb.append(separator).append("?");
+                        separator = ", ";
+                    }
+                    sb.append(")");
 
-            // Create a prepared statement to insert value from the recordIterator.
-            sb = new StringBuilder();
-            sb.append("INSERT INTO ").append(this.getTableName()).append(" (");
-            separator = "";
-            for (int i = 0; i < finalColumnNames.length; i++) {
-                sb.append(separator).append("\"").append(finalColumnNames[i]).append("\"");
-                separator = ", ";
-            }
-            sb.append(") VALUES (");
-            separator = "";
-            for (int i = 0; i < finalColumnNames.length; i++) {
-                sb.append(separator).append("?");
-                separator = ", ";
-            }
-            sb.append(")");
-            PreparedStatement ps = conn.prepareStatement(sb.toString());
-
-            // The schema Record has to be pushed to the database too.
-            this.pushToStatement(ps, firstElement, typeClass, finalColumnNames);
-            ps.addBatch();
-
-            // Iterate through all remaining records and add them to the prepared statement
-            recordIterator.forEachRemaining(
-                    r -> {
+                    try (PreparedStatement ps = conn.prepareStatement(sb.toString())) {
                         try {
-                            this.pushToStatement(ps, r, typeClass, finalColumnNames);
+                            this.pushToStatement(ps, firstElement, typeClass, finalColumnNames);
                             ps.addBatch();
-                        } catch (SQLException e) {
-                            e.printStackTrace();
-                        }
-                    });
 
-            ps.executeBatch();
-            conn.commit();
-            conn.close();
+                            recordIterator.forEachRemaining(
+                                    r -> {
+                                        try {
+                                            this.pushToStatement(ps, r, typeClass, finalColumnNames);
+                                            ps.addBatch();
+                                        } catch (SQLException e) {
+                                            throw new RuntimeException("Failed to process record for batch insert", e);
+                                        }
+                                    });
+
+                            ps.executeBatch();
+                            conn.commit();
+                        } catch (Exception e) {
+                            conn.rollback();
+                            throw e;
+                        }
+                    }
+                }
+            }
         } catch (ClassNotFoundException e) {
-            System.out.println("Please specify a correct database driver.");
-            e.printStackTrace();
+            throw new org.apache.wayang.core.api.exception.WayangException("Could not find database driver", e);
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new org.apache.wayang.core.api.exception.WayangException("Database operation failed", e);
+        } catch (Exception e) {
+            throw new org.apache.wayang.core.api.exception.WayangException("Failed to evaluate JavaTableSink", e);
         }
 
         return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
@@ -217,6 +232,11 @@ public class JavaTableSink<T> extends TableSink<T> implements JavaExecutionOpera
             throws SQLException {
         if (typeClass == Record.class) {
             Record r = (Record) element;
+            if (r.size() < columnNames.length) {
+                throw new org.apache.wayang.core.api.exception.WayangException(
+                        String.format("Record length (%d) is less than expected column count (%d)", r.size(),
+                                columnNames.length));
+            }
             for (int i = 0; i < columnNames.length; i++) {
                 setRecordValue(ps, i + 1, r.getField(i));
             }

--- a/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTableSinkTest.java
+++ b/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTableSinkTest.java
@@ -101,7 +101,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { inputChannelInstance }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt(1));
         }
@@ -117,7 +117,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         dbProps.setProperty("driver", DRIVER);
 
         JavaTableSink<TestPojo> sink = new JavaTableSink<>(dbProps, "overwrite", TABLE_NAME,
-                null, // schema detected via reflection
+                null,
                 DataSetType.createDefault(TestPojo.class));
 
         Job job = mock(Job.class);
@@ -136,7 +136,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { inputChannelInstance }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME + " ORDER BY \"id\"")) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\" ORDER BY \"id\"")) {
             rs.next();
             assertEquals(1, rs.getInt("id"));
             assertEquals("Alice", rs.getString("name"));
@@ -155,7 +155,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         dbProps.setProperty("password", "");
         dbProps.setProperty("driver", DRIVER);
 
-        // 1. Initial write (overwrite)
+        // 1. Initial write
         JavaTableSink<Record> sink1 = new JavaTableSink<>(dbProps, "overwrite", TABLE_NAME,
                 new String[] { "id", "name" },
                 DataSetType.createDefault(Record.class));
@@ -186,7 +186,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink2, new ChannelInstance[] { input2 }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt(1));
         }
@@ -201,13 +201,13 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         dbProps.setProperty("password", "");
         dbProps.setProperty("driver", DRIVER);
 
-        // 1. Create table with old schema (id, name)
+        // 1. Create table with old schema
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("CREATE TABLE " + TABLE_NAME + " (id INT, name VARCHAR(255))");
             stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Old')");
         }
 
-        // 2. Overwrite with new schema (id, age, city)
+        // 2. Overwrite with new schema
         JavaTableSink<Record> sink = new JavaTableSink<>(dbProps, "overwrite", TABLE_NAME,
                 new String[] { "id", "age", "city" },
                 DataSetType.createDefault(Record.class));
@@ -223,7 +223,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt("id"));
             assertEquals(30, rs.getInt("age"));
@@ -265,7 +265,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT \"name\" FROM " + TABLE_NAME + " WHERE \"id\" = 1")) {
+                ResultSet rs = stmt.executeQuery("SELECT \"name\" FROM \"" + TABLE_NAME + "\" WHERE \"id\" = 1")) {
             rs.next();
             assertEquals(null, rs.getString(1));
             assertTrue(rs.wasNull());
@@ -297,7 +297,7 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME + " WHERE \"id\" = 1")) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\" WHERE \"id\" = 1")) {
             rs.next();
             assertTrue(rs.getBoolean("is_active"));
             assertEquals(5000.50, rs.getDouble("salary"), 0.001);

--- a/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTextFileSourceTest.java
+++ b/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTextFileSourceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -71,7 +72,7 @@ class JavaTextFileSourceTest extends JavaExecutionOperatorTestBase {
         evaluate(source, inputs, outputs);
 
         // Verify the outcome.
-        final List<String> result = outputs[0].<String>provideStream().toList();
+        final List<String> result = outputs[0].<String>provideStream().collect(Collectors.toList());
         assertEquals(63, result.size());
     }
 
@@ -100,7 +101,7 @@ class JavaTextFileSourceTest extends JavaExecutionOperatorTestBase {
             evaluate(source, inputs, outputs);
 
             // Verify the outcome.
-            final List<String> result = outputs[0].<String>provideStream().toList();
+            final List<String> result = outputs[0].<String>provideStream().collect(Collectors.toList());
             assertEquals(225, result.size());
         } finally {
             if (javaExecutor != null)
@@ -123,7 +124,7 @@ class JavaTextFileSourceTest extends JavaExecutionOperatorTestBase {
             evaluate(source, inputs, outputs);
 
             // Verify the outcome.
-            final List<String> result = outputs[0].<String>provideStream().toList();
+            final List<String> result = outputs[0].<String>provideStream().collect(Collectors.toList());
             assertEquals(64, result.size());
         } catch (final Exception e) {
             Assumptions.assumeTrue(false, "Skipping test due to possible network error: " + e.getMessage());

--- a/wayang-platforms/wayang-spark/pom.xml
+++ b/wayang-platforms/wayang-spark/pom.xml
@@ -122,13 +122,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.2.224</version>

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.basic.util.DatabaseProduct;
 import org.apache.wayang.basic.util.SqlTypeUtils;
 import org.apache.wayang.core.api.exception.WayangException;
 import org.apache.wayang.core.optimizer.OptimizationContext;
@@ -82,21 +83,18 @@ public class SparkTableSink<T> extends TableSink<T> implements SparkExecutionOpe
 
         Dataset<Row> df;
         if (typeClass == Record.class) {
-            // Records need manual schema handling
-            if (recordRDD.isEmpty()) {
+            List<T> sample = recordRDD.take(1);
+            if (sample.isEmpty()) {
                 return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
             }
-            Record first = (Record) recordRDD.first();
+            Record first = (Record) sample.get(0);
 
-            // Centralized Schema Derivation
             List<SqlTypeUtils.SchemaField> schemaFields = SqlTypeUtils.getSchema(first,
                     SqlTypeUtils.detectProduct(this.getProperties().getProperty("url")),
                     this.getColumnNames());
 
-            // Map Record to Row
             JavaRDD<Row> rowRDD = recordRDD.map(rec -> RowFactory.create(((Record) rec).getValues()));
 
-            // Build Spark Schema
             StructField[] fields = new StructField[schemaFields.size()];
             for (int i = 0; i < schemaFields.size(); i++) {
                 SqlTypeUtils.SchemaField sf = schemaFields.get(i);
@@ -104,26 +102,41 @@ public class SparkTableSink<T> extends TableSink<T> implements SparkExecutionOpe
                 fields[i] = new StructField(sf.getName(), sparkType, true, Metadata.empty());
             }
 
-            // Update column names in the operator if they were generated
-            String[] newColNames = schemaFields.stream().map(SqlTypeUtils.SchemaField::getName).toArray(String[]::new);
-            this.setColumnNames(newColNames);
+            // We skip updating column names in the operator to avoid mutating shared state.
+            // Inferred names are used locally for df creation.
 
             df = sqlContext.createDataFrame(rowRDD, new StructType(fields));
         } else {
-            // POJO Case: Let Spark handle it natively
             df = sqlContext.createDataFrame(recordRDD, typeClass);
-            // If columnNames are provided, we should probably select/rename them,
-            // but usually createDataFrame(rdd, beanClass) maps fields to columns.
-            if (this.getColumnNames() != null && this.getColumnNames().length > 0) {
-                // Optionally filter or reorder columns to match this.getColumnNames()
-                // For now, Spark's native mapping is preferred.
+            // For POJOs, we currently do not support custom columnNames to avoid
+            // ambiguous or misleading mappings. Fail fast if they are provided.
+            String[] columnNames = this.getColumnNames();
+            if (columnNames != null && columnNames.length > 0) {
+                throw new WayangException(
+                        "columnNames are not supported for POJO inputs in SparkTableSink. " +
+                                "Either omit columnNames or use Record inputs if you need custom column mapping.");
             }
         }
 
-        this.getProperties().setProperty("batchSize", "250000");
+        Properties writeProps = new Properties();
+        writeProps.putAll(this.getProperties());
+        if (!writeProps.containsKey("batchSize")) {
+            writeProps.setProperty("batchSize", "250000");
+        }
+
+        String targetTable = this.getTableName();
+        if (targetTable != null && !targetTable.startsWith("(") && !targetTable.startsWith("\"")
+                && !targetTable.startsWith("`")) {
+            DatabaseProduct product = SqlTypeUtils.detectProduct(this.getProperties().getProperty("url"));
+            String quote = (product == DatabaseProduct.MYSQL) ? "`"
+                    : (product == DatabaseProduct.MSSQL) ? "[" : "\"";
+            String closingQuote = (product == DatabaseProduct.MSSQL) ? "]" : quote;
+            targetTable = quote + targetTable + closingQuote;
+        }
+
         df.write()
                 .mode(this.mode)
-                .jdbc(this.getProperties().getProperty("url"), this.getTableName(), this.getProperties());
+                .jdbc(this.getProperties().getProperty("url"), targetTable, writeProps);
 
         return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
     }

--- a/wayang-platforms/wayang-spark/src/test/java/org/apache/wayang/spark/operators/SparkTableSinkTest.java
+++ b/wayang-platforms/wayang-spark/src/test/java/org/apache/wayang/spark/operators/SparkTableSinkTest.java
@@ -18,14 +18,9 @@
 package org.apache.wayang.spark.operators;
 
 import org.apache.wayang.basic.data.Record;
-import org.apache.wayang.core.api.Configuration;
-import org.apache.wayang.core.api.Job;
-import org.apache.wayang.core.optimizer.OptimizationContext;
-import org.apache.wayang.core.plan.wayangplan.OutputSlot;
 import org.apache.wayang.core.platform.ChannelInstance;
 import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.spark.channels.RddChannel;
-import org.apache.wayang.spark.platform.SparkPlatform;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,8 +35,6 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test suite for {@link SparkTableSink}.
@@ -64,7 +57,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
     void teardownTest() throws Exception {
         if (connection != null && !connection.isClosed()) {
             try (Statement stmt = connection.createStatement()) {
-                stmt.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
+                stmt.execute("DROP TABLE IF EXISTS \"" + TABLE_NAME + "\"");
             }
             connection.close();
         }
@@ -72,7 +65,6 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testWritingRecordToH2() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
@@ -83,9 +75,6 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
                 new String[] { "id", "name", "value" },
                 DataSetType.createDefault(Record.class));
 
-        Job job = mock(Job.class);
-        when(job.getConfiguration()).thenReturn(configuration);
-
         Record record1 = new Record(1, "Alice", 100.5);
         Record record2 = new Record(2, "Bob", 200.75);
 
@@ -95,7 +84,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { inputChannelInstance }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt(1));
         }
@@ -103,7 +92,6 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testWritingPojoToH2() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
@@ -111,11 +99,8 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         dbProps.setProperty("driver", DRIVER);
 
         SparkTableSink<TestPojo> sink = new SparkTableSink<>(dbProps, "overwrite", TABLE_NAME,
-                null, // schema detected via reflection
+                null,
                 DataSetType.createDefault(TestPojo.class));
-
-        Job job = mock(Job.class);
-        when(job.getConfiguration()).thenReturn(configuration);
 
         TestPojo p1 = new TestPojo(1, "Alice");
         TestPojo p2 = new TestPojo(2, "Bob");
@@ -126,7 +111,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { inputChannelInstance }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME + " ORDER BY \"id\"")) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\" ORDER BY \"id\"")) {
             rs.next();
             assertEquals(1, rs.getInt("id"));
             assertEquals("Alice", rs.getString("name"));
@@ -138,14 +123,13 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testAppendMode() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
         dbProps.setProperty("password", "");
         dbProps.setProperty("driver", DRIVER);
 
-        // 1. Initial write (overwrite)
+        // 1. Initial write
         SparkTableSink<Record> sink1 = new SparkTableSink<>(dbProps, "overwrite", TABLE_NAME,
                 new String[] { "id", "name" },
                 DataSetType.createDefault(Record.class));
@@ -162,7 +146,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink2, new ChannelInstance[] { input2 }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt(1));
         }
@@ -170,20 +154,19 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testOverwriteWithSchemaMismatch() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
         dbProps.setProperty("password", "");
         dbProps.setProperty("driver", DRIVER);
 
-        // 1. Create table with old schema (id, name)
+        // 1. Create table with old schema
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("CREATE TABLE " + TABLE_NAME + " (\"id\" INT, \"name\" VARCHAR(255))");
             stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Old')");
         }
 
-        // 2. Overwrite with new schema (id, age, city)
+        // 2. Overwrite with new schema
         SparkTableSink<Record> sink = new SparkTableSink<>(dbProps, "overwrite", TABLE_NAME,
                 new String[] { "id", "age", "city" },
                 DataSetType.createDefault(Record.class));
@@ -192,7 +175,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME)) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\"")) {
             rs.next();
             assertEquals(2, rs.getInt("id"));
             assertEquals(30, rs.getInt("age"));
@@ -211,7 +194,6 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testNullValues() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
@@ -226,7 +208,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT \"name\" FROM " + TABLE_NAME + " WHERE \"id\" = 1")) {
+                ResultSet rs = stmt.executeQuery("SELECT \"name\" FROM \"" + TABLE_NAME + "\" WHERE \"id\" = 1")) {
             rs.next();
             assertEquals(null, rs.getString(1));
             assertTrue(rs.wasNull());
@@ -235,7 +217,6 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
 
     @Test
     void testSupportedTypes() throws Exception {
-        Configuration configuration = new Configuration();
         Properties dbProps = new Properties();
         dbProps.setProperty("url", JDBC_URL);
         dbProps.setProperty("user", "sa");
@@ -250,7 +231,7 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
         evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
 
         try (Statement stmt = connection.createStatement();
-                ResultSet rs = stmt.executeQuery("SELECT * FROM " + TABLE_NAME + " WHERE \"id\" = 1")) {
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\" WHERE \"id\" = 1")) {
             rs.next();
             assertTrue(rs.getBoolean("is_active"));
             assertEquals(5000.50, rs.getDouble("salary"), 0.001);


### PR DESCRIPTION
## Summary

This PR introduces a new `TableSink` operator for writing `Record` data into a database table via JDBC, with implementations for the Java and Spark platforms.

Opening as **Draft** to start discussion on the operator design and expected behavior.

## Changes

- **New operator:** `TableSink` (in `wayang-basic`)
  - A `UnarySink<Record>` that targets a table name and accepts JDBC connection `Properties`
  - Supports a write `mode` (e.g. overwrite) and optional column names

- **Java platform:** `JavaTableSink` (in `wayang-java`)
  - JDBC-based implementation that can create the target table (if missing) and batch-insert records
  - Supports `overwrite` by dropping the target table first

- **Spark platform:** `SparkTableSink` (in `wayang-spark`)
  - Spark-side implementation of the same `TableSink` operator

## Notes / open questions

- This started as a PostgreSQL sink, but the intention should likely be a **generic JDBC sink** that works across multiple databases.
- DDL generation is currently basic (e.g., columns are auto-created as `VARCHAR`s)
- `mode` behavior (overwrite vs append, etc.) should be agreed on and formalized.

## How to use / test

To run end-to-end locally, you currently need an external PostgreSQL instance available and provide JDBC connection details (driver/url/user/password) in the test setup/environment.
