### PR TITLE
fix: RecordType.hashCode() inconsistent with equals() (#694)

### DIFF
--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/types/RecordType.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/types/RecordType.java
@@ -65,7 +65,7 @@ public class RecordType extends BasicDataUnitType<Record> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fieldNames);
+        return Objects.hash(super.hashCode(), Arrays.hashCode(fieldNames));
     }
 
     @Override

--- a/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/types/RecordTypeTest.java
+++ b/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/types/RecordTypeTest.java
@@ -22,6 +22,7 @@ import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.types.DataSetType;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,5 +45,14 @@ class RecordTypeTest {
         assertFalse(t2.isSupertypeOf(t3));
         assertTrue(t3.isSupertypeOf(t3));
         assertFalse(t3.isSupertypeOf(t2));
+    }
+
+    @Test
+    void testEqualInstancesHaveSameHashCode() {
+        RecordType rt1 = new RecordType("x", "y", "z");
+        RecordType rt2 = new RecordType("x", "y", "z");
+
+        assertEquals(rt1, rt2);
+        assertEquals(rt1.hashCode(), rt2.hashCode());
     }
 }


### PR DESCRIPTION
Fixes #694

`hashCode()` was using identity hash for the `fieldNames` array instead of content hash, while `equals()` correctly uses `Arrays.equals()`. Wrapped it with `Arrays.hashCode()` and added a test.