### PR TITLE
Fix PythonApiTests Jenkins failure by using portable worker path configuration

### DIFF
--- a/wayang-api/wayang-api-python/src/test/java/org/apache/wayang/api/python/PythonApiTests.java
+++ b/wayang-api/wayang-api-python/src/test/java/org/apache/wayang/api/python/PythonApiTests.java
@@ -31,17 +31,13 @@ class PythonApiTests {
     @Test
     void processCallerSocketTest() {
         try {
-        final Configuration configuration = new Configuration();
-        final String path = Paths.get("python/worker.py").toString();
-        
-        configuration.setProperty("wayang.api.python.worker", path);
+            final Configuration configuration = new Configuration();
+            final PythonProcessCaller processCaller = new PythonProcessCaller();
 
-        final PythonProcessCaller processCaller = new PythonProcessCaller();
+            assertTrue(processCaller.getSocket().isConnected());
+            assertTrue(processCaller.isReady());
 
-        assertTrue(processCaller.getSocket().isConnected());
-        assertTrue(processCaller.isReady());
-
-        processCaller.close();
+            processCaller.close();
         } catch (Exception e) {
             assumeTrue(false, "Skipping test due to setup error: " + e.getMessage());
         }

--- a/wayang-api/wayang-api-python/src/test/resources/wayang.properties
+++ b/wayang-api/wayang-api-python/src/test/resources/wayang.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-wayang.api.python.worker = /var/www/html/python/src/pywy/execution/worker.py
+wayang.api.python.worker = ../../python/src/pywy/execution/worker.py
 wayang.api.python.path = python3
 wayang.api.python.env.path = /var/www/html/python/src
 


### PR DESCRIPTION
Fixes #642

The PythonApiTests test class was using a machine-specific absolute path for the Python worker script in the wayang.properties file, which was causing the Jenkins builds to fail in CI environments.

This PR changes the absolute path to a relative path, which is correct and portable, so that it can correctly resolve the path within the repository structure. The test class PythonApiTests was also using an unnecessary worker path override, which is removed in this PR so that it uses the test configuration provided in src/test/resources.