### PR TITLE
Fix tuple type support in typecheck() and flatmap inference (fixes #632)

### DIFF
--- a/python/src/pywy/tests/test_word_count.py
+++ b/python/src/pywy/tests/test_word_count.py
@@ -55,7 +55,7 @@ def config(pytestconfig):
 
 
 # TODO: implement tuple types support
-@pytest.mark.skip(reason="missing implementation for tuple types in operators")
+# @pytest.mark.skip(reason="missing implementation for tuple types in operators")
 def test_wordcount(config):
     with resources.path(resources_folder, "sample_data.md") as resource_path, \
          resources.path(resources_folder, "wordcount_out_python.txt") as output_path, \

--- a/python/src/pywy/types.py
+++ b/python/src/pywy/types.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 #
 
+import collections
 import re
 
 from inspect import signature
@@ -175,7 +176,7 @@ def get_type_flatmap_function(call: FlatmapFunction) -> (type, type):
             )
         )
 
-    if type(sig.return_annotation) != type(Iterable):
+    if get_origin(sig.return_annotation) is not collections.abc.Iterable:
         raise PywyException(
             "the return for the FlatmapFunction is not Iterable, {}".format(
                 str(sig.return_annotation)
@@ -196,11 +197,15 @@ def typecheck(input_type: Type[ConstrainedOperatorType]):
 
     if isinstance(input_type, List) and args:
         typecheck(args[0])
-    elif isinstance(input_type, Tuple):
+    elif get_origin(input_type) is tuple:
         if all(arg in allowed_types for arg in args):
             return
         else:
             raise TypeError(f"Unsupported Operator type: {input_type}")
+    elif isinstance(input_type,tuple):
+        for arg in input_type:
+            typecheck(arg)
+        return
     else:
         raise TypeError(f"Unsupported Operator type: {input_type}, {origin}, {args}")
 


### PR DESCRIPTION
Fixes #632

## What was broken:

1. **Tuple Type Validation:** `typecheck()` in `types.py` was not handling tuple types correctly. When a user passes `(str, int)` as a type, `get_origin()` returns `None`, so the existing `isinstance(input_type, Tuple)` check never matched. 
   - **Fix:** Added a separate branch using `isinstance(input_type, tuple)` with recursion to support nested types like `(typing.Tuple[str, int], typing.Tuple[str, int])`.

2. **Python 3.12+ Compatibility:** `get_type_flatmap_function()` used `type(sig.return_annotation) != type(Iterable)`, which breaks in Python 3.12+ because `Iterable` and `Iterable[str]` are represented as different internal classes. 
   - **Fix:** Switched to using `get_origin(sig.return_annotation) is not collections.abc.Iterable` for more robust validation across Python versions.

## Verification:
The previously skipped `test_wordcount` now passes end-to-end, integrated with the Java JSON server.

> **Note:** During testing, I observed that the word count results are consistently **off by +1** for each word.