### PR TITLE
WAYANG-49: Update outdated copyright years in markdown and resource f…

### DIFF
--- a/python/src/pywy/tests/resources/sample_data.md
+++ b/python/src/pywy/tests/resources/sample_data.md
@@ -246,7 +246,7 @@ The list of [contributors](https://github.com/apache/incubator-wayang/graphs/con
 ## License
 All files in this repository are licensed under the Apache Software License 2.0
 
-Copyright 2020 - 2025 The Apache Software Foundation.
+Copyright 2020 - 2026 The Apache Software Foundation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/wayang-applications/data/case-study/DATA_REPO_001/README.md
+++ b/wayang-applications/data/case-study/DATA_REPO_001/README.md
@@ -207,7 +207,7 @@ The list of [contributors](https://github.com/apache/incubator-wayang/graphs/con
 ## License
 All files in this repository are licensed under the Apache Software License 2.0
 
-Copyright 2020 - 2024 The Apache Software Foundation.
+Copyright 2020 - 2026 The Apache Software Foundation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/wayang-docs/src/main/resources/index.md
+++ b/wayang-docs/src/main/resources/index.md
@@ -387,7 +387,7 @@ object kmeans {
 
 All files in this repository are licensed under the Apache Software License 2.0
 
-Copyright 2020 - 2024 The Apache Software Foundation.
+Copyright 2020 - 2026 The Apache Software Foundation.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
While the main NOTICE file was updated, several other resource files (sample_data.md, case-study READMEs, and index.md) still contained outdated copyright years (2024/2025). This PR updates them to 2026 to ensure project-wide consistency.