### PR TITLE
WAYANG-678: Implement cardinality tracking in DataStreamChannel

### DIFF
--- a/wayang-platforms/wayang-flink/src/main/java/org/apache/wayang/flink/channels/DataStreamChannel.java
+++ b/wayang-platforms/wayang-flink/src/main/java/org/apache/wayang/flink/channels/DataStreamChannel.java
@@ -29,6 +29,7 @@ import org.apache.wayang.core.platform.Executor;
 import org.apache.wayang.flink.execution.FlinkExecutor;
 
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class DataStreamChannel extends Channel {
 
@@ -39,8 +40,7 @@ public class DataStreamChannel extends Channel {
 
         private DataStream<?> dataStream;
 
-        // TODO: this.size is currently always 0
-        private long size;
+        private AtomicLong counter;
 
         public Instance(final FlinkExecutor executor,
                 final OptimizationContext.OperatorContext producerOperatorContext,
@@ -49,7 +49,16 @@ public class DataStreamChannel extends Channel {
         }
 
         public void accept(final DataStream<?> dataStream) {
-            this.dataStream = dataStream;
+            if (this.isMarkedForInstrumentation()) {
+                final AtomicLong c = new AtomicLong(0L);
+                this.counter = c;
+                this.dataStream = dataStream.filter(element -> {
+                    c.incrementAndGet();
+                    return true;
+                });
+            } else {
+                this.dataStream = dataStream;
+            }
         }
 
         @SuppressWarnings("unchecked")
@@ -59,7 +68,10 @@ public class DataStreamChannel extends Channel {
 
         @Override
         public OptionalLong getMeasuredCardinality() {
-            return this.size == 0 ? super.getMeasuredCardinality() : OptionalLong.of(this.size);
+            if (this.counter != null) {
+                this.setMeasuredCardinality(this.counter.get());
+            }
+            return super.getMeasuredCardinality();
         }
 
         @Override
@@ -69,6 +81,10 @@ public class DataStreamChannel extends Channel {
 
         @Override
         protected void doDispose() {
+            if (this.counter != null) {
+                this.setMeasuredCardinality(this.counter.get());
+                this.counter = null;
+            }
             this.dataStream = null;
         }
     }


### PR DESCRIPTION
Fixes #678.

Implements cardinality tracking in DataStreamChannel.Instance using AtomicLong, following the same pattern as RddChannel in the Spark platform.

Changes:
- Replaces the always-zero size field with an AtomicLong counter
- Counter increments via a filter on the DataStream when instrumentation is enabled
- Counter is read in both getMeasuredCardinality() and doDispose()
- Mirrors the established pattern from RddChannel in wayang-spark

All 25 existing Flink tests pass.