### PR TITLE
docs: Add documentation to DataQuanta companion object

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -1310,9 +1310,7 @@ class JoinedDataQuanta[Out0: ClassTag, Out1: ClassTag]
  * Companion object for [[DataQuanta]].
  *
  * Provides factory methods to create [[DataQuanta]] instances directly
- * from [[OutputSlot]]s. This is particularly useful when integrating
- * custom operators into a [[WayangPlan]], including the DataFrame API
- * where DataQuanta[Row] forms the foundation of tabular data processing.
+ * from [[OutputSlot]]s.
  */
 object DataQuanta {
 

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/DataQuanta.scala
@@ -1307,8 +1307,12 @@ class JoinedDataQuanta[Out0: ClassTag, Out1: ClassTag]
 }
 
 /**
- * TODO: add the documentation to the object org.apache.wayang.api.DataQuanta
- * labels: documentation,todo
+ * Companion object for [[DataQuanta]].
+ *
+ * Provides factory methods to create [[DataQuanta]] instances directly
+ * from [[OutputSlot]]s. This is particularly useful when integrating
+ * custom operators into a [[WayangPlan]], including the DataFrame API
+ * where DataQuanta[Row] forms the foundation of tabular data processing.
  */
 object DataQuanta {
 


### PR DESCRIPTION
This PR adds proper Scaladoc documentation to the DataQuanta 
companion object, replacing the existing TODO comment.

The documentation describes the purpose of the companion object
and mentions its role in the DataFrame API where DataQuanta[Row]
forms the foundation of tabular data processing.

Closes #65