### PR TITLE
docs: Add documentation to DataQuantaBuilderDecorator class

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/DataQuantaBuilderDecorator.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/DataQuantaBuilderDecorator.scala
@@ -25,11 +25,13 @@ import org.apache.wayang.core.platform.Platform
 import org.apache.wayang.core.types.DataSetType
 
 /**
-  * Utility to extend a [[DataQuantaBuilder]]'s functionality by decoration.
-  */
-/**
- * TODO: add the documentation in the methods of org.apache.wayang.api.util.DataQuantaBuilderDecorator
- * labels: documentation,todo
+ * Utility to extend a [[DataQuantaBuilder]]'s functionality by decoration.
+ *
+ * DataQuantaBuilderDecorator follows the Decorator design pattern, allowing
+ * additional behaviour to be added to [[DataQuantaBuilder]] instances without
+ * modifying the original class. This is particularly useful for building
+ * flexible and composable data processing pipelines in Apache Wayang,
+ * including the upcoming DataFrame API where composable operators are essential.
  */
 abstract class DataQuantaBuilderDecorator[This <: DataQuantaBuilder[This, Out], Out]
 (baseBuilder: DataQuantaBuilder[_, Out])

--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/DataQuantaBuilderDecorator.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/util/DataQuantaBuilderDecorator.scala
@@ -29,9 +29,7 @@ import org.apache.wayang.core.types.DataSetType
  *
  * DataQuantaBuilderDecorator follows the Decorator design pattern, allowing
  * additional behaviour to be added to [[DataQuantaBuilder]] instances without
- * modifying the original class. This is particularly useful for building
- * flexible and composable data processing pipelines in Apache Wayang,
- * including the upcoming DataFrame API where composable operators are essential.
+ * modifying the original class. 
  */
 abstract class DataQuantaBuilderDecorator[This <: DataQuantaBuilder[This, Out], Out]
 (baseBuilder: DataQuantaBuilder[_, Out])


### PR DESCRIPTION
This PR adds proper Scaladoc documentation to the DataQuantaBuilderDecorator 
class, replacing the existing TODO comment.

The documentation describes the Decorator design pattern used by this class
and mentions its relevance to the upcoming DataFrame API where composable
operators are essential.

Closes #72