### PR TITLE
docs: Add documentation to Wayang API package object

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/package.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/package.scala
@@ -35,11 +35,13 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**
- * Provides implicits for the basic Wayang API.
- */
-/**
- * TODO: add the documentation in the implicit of org.apache.wayang.api
- * labels: documentation,todo
+ * Provides implicit conversions and utility methods for the Apache Wayang API.
+ *
+ * This package object contains implicit definitions that enable seamless
+ * interoperability between Scala and Java types within the Wayang API.
+ * These implicits support type inference for DataQuanta pipelines,
+ * including the upcoming DataFrame API where type information is
+ * propagated automatically through the operator chain.
  */
 package object api {
 


### PR DESCRIPTION
This PR adds proper Scaladoc documentation to the Wayang API 
package object, replacing the existing TODO comment.

The documentation describes the implicit conversions and utility 
methods provided by the package object, and mentions their role 
in supporting type inference for DataQuanta pipelines including 
the upcoming DataFrame API.

Closes #71