### PR TITLE
docs: Add documentation to Wayang API graph package object

### DIFF
--- a/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/graph/package.scala
+++ b/wayang-api/wayang-api-scala-java/src/main/scala/org/apache/wayang/api/graph/package.scala
@@ -21,14 +21,17 @@ package org.apache.wayang.api
 import org.apache.wayang.basic.data.{Tuple2 => T2}
 
 /**
-  * Provides implicits for Wayang's graph API.
-  */
+ * Provides implicit conversions and type aliases for Apache Wayang's graph API.
+ *
+ * This package object defines core type aliases used in graph processing pipelines:
+ * - Vertex: represents a graph node as a Long identifier
+ * - Edge: represents a directed connection between two vertices
+ * - PageRank: represents a vertex with its computed PageRank score
+ *
+ * These types support graph analytics operations within Wayang's
+ * cross-platform execution model.
+ */
 package object graph {
-
-  /**
-   * TODO: add the description for the implicitis in org.apache.wayang.api.graph
-   * labels: documentation,todo
-   */
 
   type Vertex = java.lang.Long
 


### PR DESCRIPTION
This PR adds proper Scaladoc documentation to the Wayang API 
graph package object, replacing the existing minimal comment.

The documentation describes the implicit conversions and type 
aliases provided by the graph package object, including Vertex, 
Edge and PageRank types used in graph processing pipelines.

Closes #70