### PR TITLE
Implement SQL `CAST` in Java filter predicates via `SqlRuntimeCast`

### DIFF
--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -84,16 +84,6 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
         }
 
         /**
-         * Java implementation of SQL cast.
-         * @param input input field
-         * @param type the new return type of the field
-         * @return Java-type equivalent to {@link SqlTypeName} counterpart.
-         */
-        private static Object sqlCast(Object input, SqlTypeName type){
-            throw new UnsupportedOperationException("sqlCasting is not yet implemented.");
-        }
-
-        /**
          * Java equivalent of SQL like clauses
          * 
          * @param s1

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/FilterPredicateImpl.java
@@ -56,8 +56,7 @@ public class FilterPredicateImpl implements FunctionDescriptor.SerializablePredi
                 case OR -> input.stream().anyMatch(obj -> Boolean.class.cast(obj).booleanValue());
                 case MINUS -> widenToDouble.apply(input.get(0)) - widenToDouble.apply(input.get(1));
                 case PLUS -> widenToDouble.apply(input.get(0)) + widenToDouble.apply(input.get(1));
-                // TODO: may need better support for CASTing in the future. See sqlCast() in this file.
-                case CAST -> input.get(0) instanceof Number ? widenToDouble.apply(input.get(0)) : ensureComparable.apply(input.get(0));
+                case CAST -> SqlRuntimeCast.castValue(input.get(0), returnType);
                 case SEARCH -> {
                     if (input.get(0) instanceof final ImmutableRangeSet range) {
                         assert input.get(1) instanceof Comparable

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -83,3 +83,16 @@ public final class SqlRuntimeCast {
         return SqlFunctions.toFloat(v);
     }
 
+    private static double castToDouble(final Object v) {
+        if (v instanceof final DateString ds) {
+            return (double) ds.getMillisSinceEpoch();
+        }
+        if (v instanceof final Date d) {
+            return (double) d.getTime();
+        }
+        if (v instanceof final Calendar cal) {
+            return (double) cal.getTimeInMillis();
+        }
+        return SqlFunctions.toDouble(v);
+    }
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -109,14 +109,14 @@ public final class SqlRuntimeCast {
     }
 
     private static String castToString(final Object v) {
-        if (v instanceof final String s) {
-            return s;
+        if (v instanceof String) {
+            return (String) v;
         }
-        if (v instanceof final NlsString nls) {
-            return nls.getValue();
+        if (v instanceof NlsString) {
+            return ((NlsString) v).getValue();
         }
-        if (v instanceof final Boolean b) {
-            return SqlFunctions.toString(b);
+        if (v instanceof Boolean) {
+            return SqlFunctions.toString((Boolean) v);
         }
         if (v instanceof final Float f) {
             return SqlFunctions.toString(f);

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -136,11 +136,11 @@ public final class SqlRuntimeCast {
         if (v instanceof Character) {
             return v.toString();
         }
-        if (v instanceof final Date d) {
-            return d.toString();
+        if (v instanceof Date) {
+            return v.toString();
         }
-        if (v instanceof final Calendar cal) {
-            return cal.getTime().toString();
+        if (v instanceof Calendar) {
+            return ((Calendar) v).getTime().toString();
         }
         return String.valueOf(v);
     }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -45,6 +45,31 @@ public final class SqlRuntimeCast {
             return null;
         }
         final Object v = unwrapForCast(input);
+        switch (target) {
+            case BOOLEAN:
+                return SqlFunctions.toBoolean(v);
+            case TINYINT:
+                return SqlFunctions.toByte(v);
+            case SMALLINT:
+                return SqlFunctions.toShort(v);
+            case INTEGER:
+                return SqlFunctions.toInt(v);
+            case BIGINT:
+                return SqlFunctions.toLong(v);
+            case DECIMAL:
+                return SqlFunctions.toBigDecimal(v);
+            case FLOAT:
+            case REAL:
+                return castToFloat(v);
+            case DOUBLE:
+                return castToDouble(v);
+            case CHAR:
+            case VARCHAR:
+                return castToString(v);
+            default:
+                throw new UnsupportedOperationException(
+                        "CAST to " + target + " is not supported in Java filter evaluation yet.");
+        }
     }
 
     private static Object unwrapForCast(final Object o) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -127,3 +127,9 @@ public final class SqlRuntimeCast {
         if (v instanceof final Date d) {
             return d.toString();
         }
+        if (v instanceof final Calendar cal) {
+            return cal.getTime().toString();
+        }
+        return String.valueOf(v);
+    }
+}

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -118,14 +118,14 @@ public final class SqlRuntimeCast {
         if (v instanceof Boolean) {
             return SqlFunctions.toString((Boolean) v);
         }
-        if (v instanceof final Float f) {
-            return SqlFunctions.toString(f);
+        if (v instanceof Float) {
+            return SqlFunctions.toString((Float) v);
         }
-        if (v instanceof final Double d) {
-            return SqlFunctions.toString(d);
+        if (v instanceof Double) {
+            return SqlFunctions.toString((Double) v);
         }
-        if (v instanceof final BigDecimal bd) {
-            return SqlFunctions.toString(bd);
+        if (v instanceof BigDecimal) {
+            return SqlFunctions.toString((BigDecimal) v);
         }
         if (v instanceof final Number n) {
             return n.toString();

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -69,3 +69,17 @@ public final class SqlRuntimeCast {
         }
         return o;
     }
+
+    private static float castToFloat(final Object v) {
+        if (v instanceof final DateString ds) {
+            return (float) ds.getMillisSinceEpoch();
+        }
+        if (v instanceof final Date d) {
+            return (float) d.getTime();
+        }
+        if (v instanceof final Calendar cal) {
+            return (float) cal.getTimeInMillis();
+        }
+        return SqlFunctions.toFloat(v);
+    }
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -127,14 +127,14 @@ public final class SqlRuntimeCast {
         if (v instanceof BigDecimal) {
             return SqlFunctions.toString((BigDecimal) v);
         }
-        if (v instanceof final Number n) {
-            return n.toString();
+        if (v instanceof Number) {
+            return ((Number) v).toString();
         }
-        if (v instanceof final DateString ds) {
-            return ds.toString();
+        if (v instanceof DateString) {
+            return v.toString();
         }
-        if (v instanceof final Character c) {
-            return c.toString();
+        if (v instanceof Character) {
+            return v.toString();
         }
         if (v instanceof final Date d) {
             return d.toString();

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -27,3 +27,36 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
 
+/**
+ * Runtime SQL {@code CAST} for Wayang Java filter evaluation, delegating to
+ * {@link SqlFunctions} where possible.
+ */
+public final class SqlRuntimeCast {
+
+    private SqlRuntimeCast() {}
+
+    /**
+     * @param input  evaluated operand (SQL NULL is {@code null})
+     * @param target destination SQL type name of the cast (from the RexCall result type)
+     * @return value suitable for comparisons and filter logic
+     */
+    public static Object castValue(final Object input, final SqlTypeName target) {
+        if (input == null) {
+            return null;
+        }
+        final Object v = unwrapForCast(input);
+        return switch (target) {
+            case BOOLEAN -> SqlFunctions.toBoolean(v);
+            case TINYINT -> SqlFunctions.toByte(v);
+            case SMALLINT -> SqlFunctions.toShort(v);
+            case INTEGER -> SqlFunctions.toInt(v);
+            case BIGINT -> SqlFunctions.toLong(v);
+            case DECIMAL -> SqlFunctions.toBigDecimal(v);
+            case FLOAT, REAL -> castToFloat(v);
+            case DOUBLE -> castToDouble(v);
+            case CHAR, VARCHAR -> castToString(v);
+            default -> throw new UnsupportedOperationException(
+                    "CAST to " + target + " is not supported in Java filter evaluation yet.");
+        };
+    }
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -60,3 +60,12 @@ public final class SqlRuntimeCast {
         };
     }
 
+    private static Object unwrapForCast(final Object o) {
+        if (o instanceof final NlsString nls) {
+            return nls.getValue();
+        }
+        if (o instanceof final Character c) {
+            return c.toString();
+        }
+        return o;
+    }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -89,21 +89,21 @@ public final class SqlRuntimeCast {
         if (v instanceof Date) {
             return (float) ((Date) v).getTime();
         }
-        if (v instanceof final Calendar cal) {
-            return (float) cal.getTimeInMillis();
+        if (v instanceof Calendar) {
+            return (float) ((Calendar) v).getTimeInMillis();
         }
         return SqlFunctions.toFloat(v);
     }
 
     private static double castToDouble(final Object v) {
-        if (v instanceof final DateString ds) {
-            return (double) ds.getMillisSinceEpoch();
+        if (v instanceof DateString) {
+            return (double) ((DateString) v).getMillisSinceEpoch();
         }
-        if (v instanceof final Date d) {
-            return (double) d.getTime();
+        if (v instanceof Date) {
+            return (double) ((Date) v).getTime();
         }
-        if (v instanceof final Calendar cal) {
-            return (double) cal.getTimeInMillis();
+        if (v instanceof Calendar) {
+            return (double) ((Calendar) v).getTimeInMillis();
         }
         return SqlFunctions.toDouble(v);
     }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -112,3 +112,18 @@ public final class SqlRuntimeCast {
         if (v instanceof final Double d) {
             return SqlFunctions.toString(d);
         }
+        if (v instanceof final BigDecimal bd) {
+            return SqlFunctions.toString(bd);
+        }
+        if (v instanceof final Number n) {
+            return n.toString();
+        }
+        if (v instanceof final DateString ds) {
+            return ds.toString();
+        }
+        if (v instanceof final Character c) {
+            return c.toString();
+        }
+        if (v instanceof final Date d) {
+            return d.toString();
+        }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -76,18 +76,18 @@ public final class SqlRuntimeCast {
         if (o instanceof NlsString) {
             return ((NlsString) o).getValue();
         }
-        if (o instanceof final Character c) {
-            return c.toString();
+        if (o instanceof Character) {
+            return o.toString();
         }
         return o;
     }
 
     private static float castToFloat(final Object v) {
-        if (v instanceof final DateString ds) {
-            return (float) ds.getMillisSinceEpoch();
+        if (v instanceof DateString) {
+            return (float) ((DateString) v).getMillisSinceEpoch();
         }
-        if (v instanceof final Date d) {
-            return (float) d.getTime();
+        if (v instanceof Date) {
+            return (float) ((Date) v).getTime();
         }
         if (v instanceof final Calendar cal) {
             return (float) cal.getTimeInMillis();

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -16,3 +16,14 @@
  * limitations under the License.
  */
 
+package org.apache.wayang.api.sql.calcite.converter.functions;
+
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apache.calcite.runtime.SqlFunctions;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.NlsString;
+

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -96,3 +96,19 @@ public final class SqlRuntimeCast {
         return SqlFunctions.toDouble(v);
     }
 
+    private static String castToString(final Object v) {
+        if (v instanceof final String s) {
+            return s;
+        }
+        if (v instanceof final NlsString nls) {
+            return nls.getValue();
+        }
+        if (v instanceof final Boolean b) {
+            return SqlFunctions.toString(b);
+        }
+        if (v instanceof final Float f) {
+            return SqlFunctions.toString(f);
+        }
+        if (v instanceof final Double d) {
+            return SqlFunctions.toString(d);
+        }

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -45,19 +45,6 @@ public final class SqlRuntimeCast {
             return null;
         }
         final Object v = unwrapForCast(input);
-        return switch (target) {
-            case BOOLEAN -> SqlFunctions.toBoolean(v);
-            case TINYINT -> SqlFunctions.toByte(v);
-            case SMALLINT -> SqlFunctions.toShort(v);
-            case INTEGER -> SqlFunctions.toInt(v);
-            case BIGINT -> SqlFunctions.toLong(v);
-            case DECIMAL -> SqlFunctions.toBigDecimal(v);
-            case FLOAT, REAL -> castToFloat(v);
-            case DOUBLE -> castToDouble(v);
-            case CHAR, VARCHAR -> castToString(v);
-            default -> throw new UnsupportedOperationException(
-                    "CAST to " + target + " is not supported in Java filter evaluation yet.");
-        };
     }
 
     private static Object unwrapForCast(final Object o) {

--- a/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
+++ b/wayang-api/wayang-api-sql/src/main/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCast.java
@@ -73,8 +73,8 @@ public final class SqlRuntimeCast {
     }
 
     private static Object unwrapForCast(final Object o) {
-        if (o instanceof final NlsString nls) {
-            return nls.getValue();
+        if (o instanceof NlsString) {
+            return ((NlsString) o).getValue();
         }
         if (o instanceof final Character c) {
             return c.toString();

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/SqlToWayangRelTest.java
@@ -173,6 +173,23 @@ class SqlToWayangRelTest {
     }
 
     @Test
+    void javaFilterWithCastIntColumnToVarchar() throws Exception {
+        final SqlContext sqlContext = this.createSqlContext("/data/exampleInt.csv");
+        final Tuple2<Collection<Record>, WayangPlan> t = this.buildCollectorAndWayangPlan(sqlContext,
+                "SELECT * FROM fs.exampleInt WHERE CAST(NAMEB AS VARCHAR) = '1'");
+        final Collection<Record> result = t.field0;
+        final WayangPlan wayangPlan = t.field1;
+
+        PlanTraversal.upstream().traverse(wayangPlan.getSinks()).getTraversedNodes()
+                .forEach(node -> node.addTargetPlatform(Java.platform()));
+
+        sqlContext.execute(wayangPlan);
+
+        assertTrue(!result.isEmpty());
+        assertTrue(result.stream().allMatch(field -> field.getField(1).equals(1)));
+    }
+
+    @Test
     void sqlApiSourceTest() throws Exception {
         final JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl();
         final RexBuilder rexBuilder = new RexBuilder(typeFactory);

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -62,4 +62,20 @@ class SqlRuntimeCastTest {
         assertEquals(true, SqlRuntimeCast.castValue("TRUE", SqlTypeName.BOOLEAN));
     }
 
+    @Test
+    void castInvalidBooleanThrows() {
+        assertThrows(RuntimeException.class, () -> SqlRuntimeCast.castValue("maybe", SqlTypeName.BOOLEAN));
+    }
+
+    @Test
+    void castBigDecimalToVarcharUsesSqlFormat() {
+        final String s = SqlRuntimeCast.castValue(BigDecimal.valueOf(1, 1), SqlTypeName.VARCHAR).toString();
+        assertTrue(s.contains("1"));
+    }
+
+    @Test
+    void castToDateUnsupported() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> SqlRuntimeCast.castValue("2020-01-01", SqlTypeName.DATE));
+    }
 }

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -28,3 +28,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.junit.jupiter.api.Test;
 
+class SqlRuntimeCastTest {
+
+    @Test
+    void castNullYieldsNull() {
+        assertNull(SqlRuntimeCast.castValue(null, SqlTypeName.INTEGER));
+    }
+
+}

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -16,3 +16,15 @@
  * limitations under the License.
  */
 
+package org.apache.wayang.api.sql.calcite.converter.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.junit.jupiter.api.Test;
+

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -35,4 +35,14 @@ class SqlRuntimeCastTest {
         assertNull(SqlRuntimeCast.castValue(null, SqlTypeName.INTEGER));
     }
 
+    @Test
+    void castIntegerToVarchar() {
+        assertEquals("1", SqlRuntimeCast.castValue(1, SqlTypeName.VARCHAR));
+    }
+
+    @Test
+    void castStringToInteger() {
+        assertEquals(42, SqlRuntimeCast.castValue("42", SqlTypeName.INTEGER));
+    }
+
 }

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -56,4 +56,10 @@ class SqlRuntimeCastTest {
         assertEquals(7, SqlRuntimeCast.castValue(nls, SqlTypeName.INTEGER));
     }
 
+    @Test
+    void castStringToBoolean() {
+        assertTrue(SqlRuntimeCast.castValue("TRUE", SqlTypeName.BOOLEAN) instanceof Boolean);
+        assertEquals(true, SqlRuntimeCast.castValue("TRUE", SqlTypeName.BOOLEAN));
+    }
+
 }

--- a/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
+++ b/wayang-api/wayang-api-sql/src/test/java/org/apache/wayang/api/sql/calcite/converter/functions/SqlRuntimeCastTest.java
@@ -45,4 +45,15 @@ class SqlRuntimeCastTest {
         assertEquals(42, SqlRuntimeCast.castValue("42", SqlTypeName.INTEGER));
     }
 
+    @Test
+    void castStringToDouble() {
+        assertEquals(1.5d, (Double) SqlRuntimeCast.castValue("1.5", SqlTypeName.DOUBLE), 1e-9);
+    }
+
+    @Test
+    void castNlsStringToInteger() {
+        final NlsString nls = new NlsString("7", "UTF-8", null);
+        assertEquals(7, SqlRuntimeCast.castValue(nls, SqlTypeName.INTEGER));
+    }
+
 }


### PR DESCRIPTION
### Summary

Filter pushdown in **wayang-api-sql** previously evaluated `CAST` with a heuristic (`Number` → `double`, else `ensureComparable`), which broke valid SQL such as **`CAST(integer_column AS VARCHAR)`** (it widened to `double` instead of producing a string). The private **`sqlCast`** method was never invoked and always threw `UnsupportedOperationException`.

Fixes (https://github.com/apache/wayang/issues/676)

### What changed

- Added **`SqlRuntimeCast.castValue(Object, SqlTypeName)`**, delegating to Apache Calcite **`SqlFunctions`** for boolean, integral, decimal, approximate numeric, and character string targets, with unwraps for **`NlsString`** / **`Character`** consistent with the rest of the filter code.
- **`FilterPredicateImpl`** now uses the Rex call’s **result type** (`SqlTypeName` from `CallTreeFactory`) for `CAST`, matching the actual SQL cast target.
- Removed the dead **`sqlCast`** stub from `FilterPredicateImpl` to avoid duplicate, misleading APIs: behavior lives in one place (`SqlRuntimeCast`), is testable, and is documented on the class Javadoc.
- Tests: unit tests in **wayang-api-sql**, regression **`CAST(NAMEB AS VARCHAR) = '1'`** on integer CSV data, plus this **demo module** for a runnable sample and enum-wide coverage.

### Why remove `sqlCast` in `FilterPredicateImpl` and added `SqlRuntimeCast` as separate file?

- I migrated sqlCast to a standalone SqlRuntimeCast class to establish a unified, public static utility. This centralized approach allows for better reuse within the CAST switch and ensures a single source of truth for supported types. 

### How to verify

Option A : 

```bash
./mvnw -pl wayang-api/wayang-api-sql test
```
Expected Output : -

<img width="1950" height="1074" alt="image" src="https://github.com/user-attachments/assets/8869f62a-0fa3-404c-a9e9-832aa313cd07" />




Option B : 

For extended testing, I have provided a dedicated repository: [https://github.com/dileepapeiris/fix-for-apache-wayang-api-sql-cast-issue](https://github.com/dileepapeiris/fix-for-apache-wayang-api-sql-cast-issue ) . Refer to the README in that repository for detailed execution steps.

---
