### PR TITLE
Simplify condition concatenation in SQL generation for JdbcExecutor

### DIFF
--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
@@ -223,11 +223,7 @@ public class JdbcExecutor extends ExecutorTemplate {
         }
         if (!conditions.isEmpty()) {
             sb.append(" WHERE ");
-            String separator = "";
-            for (final String condition : conditions) {
-                sb.append(separator).append(condition);
-                separator = " AND ";
-            }
+            sb.append(String.join(" AND ", conditions));
         }
         sb.append(';');
         return sb;


### PR DESCRIPTION
The PR makes handling filters while writing SQL queries in the JdbcExecutor easier.

Instead of having to consider adding separators while looping, `String.join` will be used to join filters, resulting in clearer code and reduced risk of errors in formatting.

It doesn’t have any impact on how the query functions but makes it more understandable.