### PR TITLE
Add in-database JdbcTableSinkOperator for SQL-level table writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ pom.xml.*
 # Scala Plugin for VSCode
 .metals
 .bloop/
-

--- a/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/mapping/Mappings.java
+++ b/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/mapping/Mappings.java
@@ -30,7 +30,8 @@ public class Mappings {
 
     public static final Collection<Mapping> ALL = Arrays.asList(
             new FilterMapping(),
-            new ProjectionMapping()
+            new ProjectionMapping(),
+            new TableSinkMapping()
     );
 
 }

--- a/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/mapping/TableSinkMapping.java
+++ b/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/mapping/TableSinkMapping.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.genericjdbc.mapping;
+
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.core.mapping.Mapping;
+import org.apache.wayang.core.mapping.OperatorPattern;
+import org.apache.wayang.core.mapping.PlanTransformation;
+import org.apache.wayang.core.mapping.ReplacementSubplanFactory;
+import org.apache.wayang.core.mapping.SubplanPattern;
+import org.apache.wayang.genericjdbc.operators.GenericJdbcTableSinkOperator;
+import org.apache.wayang.genericjdbc.platform.GenericJdbcPlatform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link TableSink} to {@link GenericJdbcTableSinkOperator}.
+ */
+public class TableSinkMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                GenericJdbcPlatform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern<TableSink> operatorPattern = new OperatorPattern<>(
+                "sink", new TableSink<>(null, null, null), false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<TableSink>(
+                (matchedOperator, epoch) -> new GenericJdbcTableSinkOperator(matchedOperator).at(epoch)
+        );
+    }
+}

--- a/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/operators/GenericJdbcTableSinkOperator.java
+++ b/wayang-platforms/wayang-generic-jdbc/src/main/java/org/apache/wayang/genericjdbc/operators/GenericJdbcTableSinkOperator.java
@@ -16,22 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.wayang.sqlite3.mapping;
+package org.apache.wayang.genericjdbc.operators;
 
-import org.apache.wayang.core.mapping.Mapping;
-
-import java.util.Arrays;
-import java.util.Collection;
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
 
 /**
- * Register for the {@link Mapping}s supported for this platform.
+ * GenericJdbc implementation of the {@link JdbcTableSinkOperator}.
  */
-public class Mappings {
+public class GenericJdbcTableSinkOperator extends JdbcTableSinkOperator implements GenericJdbcExecutionOperator {
 
-    public static final Collection<Mapping> ALL = Arrays.asList(
-            new FilterMapping(),
-            new ProjectionMapping(),
-            new TableSinkMapping()
-    );
+    public GenericJdbcTableSinkOperator(String tableName, String[] columnNames) {
+        super(tableName, columnNames);
+    }
 
+    public GenericJdbcTableSinkOperator(TableSink<Record> that) {
+        super(that);
+    }
 }

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
@@ -40,6 +40,7 @@ import org.apache.wayang.jdbc.operators.JdbcExecutionOperator;
 import org.apache.wayang.jdbc.operators.JdbcFilterOperator;
 import org.apache.wayang.jdbc.operators.JdbcJoinOperator;
 import org.apache.wayang.jdbc.operators.JdbcProjectionOperator;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
 import org.apache.wayang.jdbc.operators.JdbcTableSource;
 import org.apache.wayang.jdbc.platform.JdbcPlatformTemplate;
 import org.apache.logging.log4j.LogManager;
@@ -52,6 +53,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
@@ -78,14 +80,96 @@ public class JdbcExecutor extends ExecutorTemplate {
 
     @Override
     public void execute(final ExecutionStage stage, final OptimizationContext optimizationContext, final ExecutionState executionState) {
-        final Tuple2<String, SqlQueryChannel.Instance> pair = JdbcExecutor.createSqlQuery(stage, optimizationContext, this);
-        final String query = pair.field0;
-        final SqlQueryChannel.Instance queryChannel = pair.field1;
+        // Check if this stage ends with a sink operator
+        final Collection<?> termTasks = stage.getTerminalTasks();
+        assert termTasks.size() == 1 : "Invalid JDBC stage: multiple terminal tasks are not currently supported.";
+        final ExecutionTask termTask = (ExecutionTask) termTasks.toArray()[0];
 
-        queryChannel.setSqlQuery(query);
+        if (termTask.getOperator() instanceof JdbcTableSinkOperator) {
+            // If it is a sink stage: compose and execute SQL directly within the database
+            JdbcExecutor.executeSinkStage(stage, optimizationContext, this);
+        } else {
+            //If it is normal stage: compose SQL and store in channel for downstream consumption
+            final Tuple2<String, SqlQueryChannel.Instance> pair = JdbcExecutor.createSqlQuery(stage, optimizationContext, this);
+            final String query = pair.field0;
+            final SqlQueryChannel.Instance queryChannel = pair.field1;
+            queryChannel.setSqlQuery(query);
+            executionState.register(queryChannel);
+        }
+    }
 
-        // Return the tipChannelInstance.
-        executionState.register(queryChannel);
+    /**
+     * Handles execution stages that end with a {@link JdbcTableSinkOperator}.
+     * Composes a SQL query from the stage's operators and executes it directly
+     * on the database connection, keeping all data within the database.
+     *
+     * @param stage               the execution stage ending with a sink
+     * @param optimizationContext provides optimization information
+     * @param jdbcExecutor        the executor with the database connection
+     */
+    private static void executeSinkStage(final ExecutionStage stage,
+                                         final OptimizationContext optimizationContext,
+                                         final JdbcExecutor jdbcExecutor) {
+        final Collection<?> startTasks = stage.getStartTasks();
+        final Collection<?> termTasks = stage.getTerminalTasks();
+
+        assert startTasks.size() == 1 : "Invalid JDBC stage: multiple sources are not currently supported";
+        final ExecutionTask startTask = (ExecutionTask) startTasks.toArray()[0];
+        assert termTasks.size() == 1 : "Invalid JDBC stage: multiple terminal tasks are not currently supported.";
+        final ExecutionTask termTask = (ExecutionTask) termTasks.toArray()[0];
+        assert startTask.getOperator() instanceof TableSource
+                : "Invalid JDBC stage: Start task has to be a TableSource";
+        assert termTask.getOperator() instanceof JdbcTableSinkOperator
+                : "Invalid JDBC stage: Terminal task has to be a JdbcTableSinkOperator";
+
+        // Extract operators from the stage
+        final JdbcTableSource tableOp = (JdbcTableSource) startTask.getOperator();
+        final JdbcTableSinkOperator sinkOp = (JdbcTableSinkOperator) termTask.getOperator();
+        final Collection<JdbcFilterOperator> filterTasks = new ArrayList<>(4);
+        JdbcProjectionOperator projectionTask = null;
+        final Collection<JdbcJoinOperator<?>> joinTasks = new ArrayList<>();
+
+        // Walk through intermediate operators, stopping at the sink
+        ExecutionTask nextTask = JdbcExecutor.findJdbcExecutionOperatorTaskInStage(startTask, stage);
+        while (nextTask != null && !(nextTask.getOperator() instanceof JdbcTableSinkOperator)) {
+            if (nextTask.getOperator() instanceof final JdbcFilterOperator filterOperator) {
+                filterTasks.add(filterOperator);
+            } else if (nextTask.getOperator() instanceof JdbcProjectionOperator projectionOperator) {
+                assert projectionTask == null;
+                projectionTask = projectionOperator;
+            } else if (nextTask.getOperator() instanceof JdbcJoinOperator joinOperator) {
+                joinTasks.add(joinOperator);
+            } else {
+                throw new WayangException(String.format("Unsupported JDBC execution task %s", nextTask.toString()));
+            }
+            nextTask = JdbcExecutor.findJdbcExecutionOperatorTaskInStage(nextTask, stage);
+        }
+
+        // Compose the SELECT query
+        final StringBuilder selectQuery = createSqlString(jdbcExecutor, tableOp, filterTasks, projectionTask, joinTasks);
+
+        // Remove trailing semicolon from SELECT
+        String selectSql = selectQuery.toString();
+        if (selectSql.endsWith(";")) {
+            selectSql = selectSql.substring(0, selectSql.length() - 1);
+        }
+
+        // Get the sink's SQL clause
+        final String sinkClause = sinkOp.createSqlClause(jdbcExecutor.connection, jdbcExecutor.functionCompiler);
+
+        // Execute on the database
+        try (Statement stmt = jdbcExecutor.connection.createStatement()) {
+            // Handle overwrite: drop existing table first
+            if ("overwrite".equals(sinkOp.getMode())) {
+                stmt.execute("DROP TABLE IF EXISTS " + sinkOp.getTableName());
+            }
+            // Execute the composed query: CREATE TABLE x AS SELECT ... or INSERT INTO x SELECT ...
+            final String fullSql = sinkClause + " " + selectSql;
+            stmt.execute(fullSql);
+            jdbcExecutor.logger.info("Executed SQL sink: {}", fullSql);
+        } catch (SQLException e) {
+            throw new WayangException("Failed to execute SQL sink on table: " + sinkOp.getTableName(), e);
+        }
     }
 
     /**

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
@@ -164,7 +164,7 @@ public class JdbcExecutor extends ExecutorTemplate {
                 stmt.execute("DROP TABLE IF EXISTS " + sinkOp.getTableName());
             }
             // Execute the composed query: CREATE TABLE x AS SELECT ... or INSERT INTO x SELECT ...
-            final String fullSql = sinkClause + " " + selectSql;
+            final String fullSql = sinkClause + " " + selectSql + sinkOp.createSqlSuffix();
             stmt.execute(fullSql);
             jdbcExecutor.logger.info("Executed SQL sink: {}", fullSql);
         } catch (SQLException e) {

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcTableSinkOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcTableSinkOperator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.jdbc.operators;
+
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.optimizer.costs.LoadProfileEstimator;
+import org.apache.wayang.core.platform.ChannelDescriptor;
+import org.apache.wayang.jdbc.compiler.FunctionCompiler;
+
+import java.sql.Connection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstract JDBC-based implementation of {@link TableSink} that operates within
+ * the {@link org.apache.wayang.jdbc.channels.SqlQueryChannel} ecosystem.
+ * Instead of pulling data into Java/Spark memory and inserting via JDBC,
+ * this operator wraps the composed SQL query in a CREATE TABLE AS SELECT
+ * or INSERT INTO ... SELECT statement, keeping all data within the database.
+ */
+public abstract class JdbcTableSinkOperator extends TableSink<Record> implements JdbcExecutionOperator {
+
+    public JdbcTableSinkOperator(String tableName, String[] columnNames) {
+        super(null, null, tableName, columnNames);
+    }
+
+    public JdbcTableSinkOperator(TableSink<Record> that) {
+        super(that);
+    }
+
+    @Override
+    public String createSqlClause(Connection connection, FunctionCompiler compiler) {
+        String mode = this.getMode();
+        if ("overwrite".equals(mode)) {
+            return "CREATE TABLE " + this.getTableName() + " AS";
+        }
+        return "INSERT INTO " + this.getTableName();
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        return Collections.singletonList(this.getPlatform().getSqlQueryChannelDescriptor());
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        throw new UnsupportedOperationException("This operator has no outputs.");
+    }
+
+    @Override
+    public String getLoadProfileEstimatorConfigurationKey() {
+        return String.format("wayang.%s.tablesink.load", this.getPlatform().getPlatformId());
+    }
+
+    @Override
+    public Optional<LoadProfileEstimator> createLoadProfileEstimator(Configuration configuration) {
+        return JdbcExecutionOperator.super.createLoadProfileEstimator(configuration);
+    }
+}

--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcTableSinkOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/operators/JdbcTableSinkOperator.java
@@ -56,6 +56,16 @@ public abstract class JdbcTableSinkOperator extends TableSink<Record> implements
         return "INSERT INTO " + this.getTableName();
     }
 
+    /**
+     * Returns a SQL suffix appended after the composed SELECT query.
+     * Default is empty, which works for most databases (PostgreSQL, SQLite, MySQL).
+     * Subclasses can potentiallyoverride for dialect-specific syntax (e.g., HSQLDB that we used for the tests requires
+     * parenthesized subquery form: {@code CREATE TABLE x AS (SELECT ...)}).
+     */
+    public String createSqlSuffix() {
+        return "";
+    }
+
     @Override
     public List<ChannelDescriptor> getSupportedInputChannels(int index) {
         return Collections.singletonList(this.getPlatform().getSqlQueryChannelDescriptor());

--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/execution/JdbcTableSinkExecutorTest.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/execution/JdbcTableSinkExecutorTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.jdbc.execution;
+
+import org.apache.wayang.core.api.Configuration;
+import org.apache.wayang.core.api.Job;
+import org.apache.wayang.core.optimizer.DefaultOptimizationContext;
+import org.apache.wayang.core.plan.executionplan.ExecutionStage;
+import org.apache.wayang.core.plan.executionplan.ExecutionTask;
+import org.apache.wayang.core.platform.CrossPlatformExecutor;
+import org.apache.wayang.core.profiling.NoInstrumentationStrategy;
+import org.apache.wayang.jdbc.channels.SqlQueryChannel;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
+import org.apache.wayang.jdbc.operators.JdbcTableSource;
+import org.apache.wayang.jdbc.test.HsqldbPlatform;
+import org.apache.wayang.jdbc.test.HsqldbTableSinkOperator;
+import org.apache.wayang.jdbc.test.HsqldbTableSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test suite for in-database table sink execution via {@link JdbcExecutor#executeSinkStage}.
+ */
+class JdbcTableSinkExecutorTest {
+
+    @Test
+    void testOverwriteModeCreatesNewTable() throws SQLException {
+        Configuration configuration = new Configuration();
+        HsqldbPlatform hsqldbPlatform = new HsqldbPlatform();
+
+        // Create source table with data
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            stmt.execute("DROP TABLE IF EXISTS source_overwrite;");
+            stmt.execute("DROP TABLE IF EXISTS target_overwrite;");
+            stmt.execute("CREATE TABLE source_overwrite (id INT, name VARCHAR(50));");
+            stmt.execute("INSERT INTO source_overwrite VALUES (1, 'Jenny');");
+            stmt.execute("INSERT INTO source_overwrite VALUES (2, 'Nick');");
+            stmt.execute("INSERT INTO source_overwrite VALUES (3, 'Klaudia');");
+        }
+
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        when(job.getCrossPlatformExecutor()).thenReturn(
+                new CrossPlatformExecutor(job, new NoInstrumentationStrategy()));
+        SqlQueryChannel.Descriptor sqlChannelDescriptor =
+                HsqldbPlatform.getInstance().getSqlQueryChannelDescriptor();
+
+        //Build the execution stage source to sink
+        ExecutionStage sqlStage = mock(ExecutionStage.class);
+
+        JdbcTableSource tableSource = new HsqldbTableSource("source_overwrite");
+        ExecutionTask tableSourceTask = new ExecutionTask(tableSource);
+        tableSourceTask.setOutputChannel(0,
+                new SqlQueryChannel(sqlChannelDescriptor, tableSource.getOutput(0)));
+        tableSourceTask.setStage(sqlStage);
+
+        JdbcTableSinkOperator sinkOp = new HsqldbTableSinkOperator(
+                "target_overwrite", new String[]{"id", "name"});
+        sinkOp.setMode("overwrite");
+        ExecutionTask sinkTask = new ExecutionTask(sinkOp);
+        sinkTask.setStage(sqlStage);
+        tableSourceTask.getOutputChannel(0).addConsumer(sinkTask, 0);
+
+        when(sqlStage.getStartTasks()).thenReturn(Collections.singleton(tableSourceTask));
+        when(sqlStage.getTerminalTasks()).thenReturn(Collections.singleton(sinkTask));
+
+        // Execute
+        JdbcExecutor executor = new JdbcExecutor(HsqldbPlatform.getInstance(), job);
+        executor.execute(sqlStage, new DefaultOptimizationContext(job), job.getCrossPlatformExecutor());
+
+        // Verify table was created and contains all 3 rows
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM target_overwrite;");
+            rs.next();
+            assertEquals(3, rs.getInt(1));
+
+            rs = stmt.executeQuery("SELECT id, name FROM target_overwrite ORDER BY id;");
+            rs.next();
+            assertEquals(1, rs.getInt("id"));
+            assertEquals("Jenny", rs.getString("name"));
+            rs.next();
+            assertEquals(2, rs.getInt("id"));
+            assertEquals("Nick", rs.getString("name"));
+            rs.next();
+            assertEquals(3, rs.getInt("id"));
+            assertEquals("Klaudia", rs.getString("name"));
+        }
+    }
+
+    @Test
+    void testOverwriteModeReplacesExistingTable() throws SQLException {
+        Configuration configuration = new Configuration();
+        HsqldbPlatform hsqldbPlatform = new HsqldbPlatform();
+
+        // Create source table and a pre-existing target table
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            stmt.execute("DROP TABLE IF EXISTS source_replace;");
+            stmt.execute("DROP TABLE IF EXISTS target_replace;");
+            stmt.execute("CREATE TABLE source_replace (id INT, val VARCHAR(50));");
+            stmt.execute("INSERT INTO source_replace VALUES (1, 'new_data');");
+            // Pre existing target table with different schema and data
+            stmt.execute("CREATE TABLE target_replace (x INT, y INT, z INT);");
+            stmt.execute("INSERT INTO target_replace VALUES (50, 20, 10);");
+        }
+
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        when(job.getCrossPlatformExecutor()).thenReturn(
+                new CrossPlatformExecutor(job, new NoInstrumentationStrategy()));
+        SqlQueryChannel.Descriptor sqlChannelDescriptor =
+                HsqldbPlatform.getInstance().getSqlQueryChannelDescriptor();
+
+        ExecutionStage sqlStage = mock(ExecutionStage.class);
+
+        JdbcTableSource tableSource = new HsqldbTableSource("source_replace");
+        ExecutionTask tableSourceTask = new ExecutionTask(tableSource);
+        tableSourceTask.setOutputChannel(0,
+                new SqlQueryChannel(sqlChannelDescriptor, tableSource.getOutput(0)));
+        tableSourceTask.setStage(sqlStage);
+
+        JdbcTableSinkOperator sinkOp = new HsqldbTableSinkOperator(
+                "target_replace", new String[]{"id", "val"});
+        sinkOp.setMode("overwrite");
+        ExecutionTask sinkTask = new ExecutionTask(sinkOp);
+        sinkTask.setStage(sqlStage);
+        tableSourceTask.getOutputChannel(0).addConsumer(sinkTask, 0);
+
+        when(sqlStage.getStartTasks()).thenReturn(Collections.singleton(tableSourceTask));
+        when(sqlStage.getTerminalTasks()).thenReturn(Collections.singleton(sinkTask));
+
+        JdbcExecutor executor = new JdbcExecutor(HsqldbPlatform.getInstance(), job);
+        executor.execute(sqlStage, new DefaultOptimizationContext(job), job.getCrossPlatformExecutor());
+
+        // Verify target was replaced. Old data should be gone, new schema and data present
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM target_replace;");
+            rs.next();
+            assertEquals(1, rs.getInt(1));
+
+            rs = stmt.executeQuery("SELECT id, val FROM target_replace;");
+            rs.next();
+            assertEquals(1, rs.getInt("id"));
+            assertEquals("new_data", rs.getString("val"));
+        }
+    }
+
+    @Test
+    void testAppendModeInsertsIntoExistingTable() throws SQLException {
+        Configuration configuration = new Configuration();
+        HsqldbPlatform hsqldbPlatform = new HsqldbPlatform();
+
+        //Create source and target table. Target has existing data.
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            stmt.execute("DROP TABLE IF EXISTS source_append;");
+            stmt.execute("DROP TABLE IF EXISTS target_append;");
+            stmt.execute("CREATE TABLE source_append (id INT, name VARCHAR(50));");
+            stmt.execute("INSERT INTO source_append VALUES (10, 'Ten');");
+            stmt.execute("INSERT INTO source_append VALUES (20, 'Twenty');");
+            stmt.execute("CREATE TABLE target_append (id INT, name VARCHAR(50));");
+            stmt.execute("INSERT INTO target_append VALUES (1, 'Existing');");
+        }
+
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        when(job.getCrossPlatformExecutor()).thenReturn(
+                new CrossPlatformExecutor(job, new NoInstrumentationStrategy()));
+        SqlQueryChannel.Descriptor sqlChannelDescriptor =
+                HsqldbPlatform.getInstance().getSqlQueryChannelDescriptor();
+
+        ExecutionStage sqlStage = mock(ExecutionStage.class);
+
+        JdbcTableSource tableSource = new HsqldbTableSource("source_append");
+        ExecutionTask tableSourceTask = new ExecutionTask(tableSource);
+        tableSourceTask.setOutputChannel(0,
+                new SqlQueryChannel(sqlChannelDescriptor, tableSource.getOutput(0)));
+        tableSourceTask.setStage(sqlStage);
+
+        JdbcTableSinkOperator sinkOp = new HsqldbTableSinkOperator(
+                "target_append", new String[]{"id", "name"});
+        sinkOp.setMode("append");
+        ExecutionTask sinkTask = new ExecutionTask(sinkOp);
+        sinkTask.setStage(sqlStage);
+        tableSourceTask.getOutputChannel(0).addConsumer(sinkTask, 0);
+
+        when(sqlStage.getStartTasks()).thenReturn(Collections.singleton(tableSourceTask));
+        when(sqlStage.getTerminalTasks()).thenReturn(Collections.singleton(sinkTask));
+
+        JdbcExecutor executor = new JdbcExecutor(HsqldbPlatform.getInstance(), job);
+        executor.execute(sqlStage, new DefaultOptimizationContext(job), job.getCrossPlatformExecutor());
+
+        // Verify existing data remains and new data is appended
+        try (Connection conn = hsqldbPlatform.createDatabaseDescriptor(configuration).createJdbcConnection()) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM target_append;");
+            rs.next();
+            assertEquals(3, rs.getInt(1));
+
+            // Verify the pre-existing row is still there
+            rs = stmt.executeQuery("SELECT COUNT(*) FROM target_append WHERE id = 1;");
+            rs.next();
+            assertEquals(1, rs.getInt(1));
+
+            // Verify the new rows were appended
+            rs = stmt.executeQuery("SELECT COUNT(*) FROM target_append WHERE id >= 10;");
+            rs.next();
+            assertEquals(2, rs.getInt(1));
+        }
+    }
+
+    @Test
+    void testOverwriteClauseGeneration() {
+        JdbcTableSinkOperator sinkOp = new HsqldbTableSinkOperator(
+                "my_table", new String[]{"col1"});
+        sinkOp.setMode("overwrite");
+        assertEquals("CREATE TABLE my_table AS (", sinkOp.createSqlClause(null, null));
+    }
+
+    @Test
+    void testAppendClauseGeneration() {
+        JdbcTableSinkOperator sinkOp = new HsqldbTableSinkOperator(
+                "my_table", new String[]{"col1"});
+        sinkOp.setMode("append");
+        assertEquals("INSERT INTO my_table", sinkOp.createSqlClause(null, null));
+}
+}

--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/test/HsqldbTableSinkOperator.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/test/HsqldbTableSinkOperator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.jdbc.test;
+
+import org.apache.wayang.core.platform.ChannelDescriptor;
+import org.apache.wayang.jdbc.compiler.FunctionCompiler;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
+
+import java.sql.Connection;
+import java.util.List;
+
+/**
+ * Test implementation of {@link JdbcTableSinkOperator}.
+ * Overrides SQL generation to use HSQLDB's CREATE TABLE AS syntax with parentheses.
+ */
+public class HsqldbTableSinkOperator extends JdbcTableSinkOperator {
+
+    public HsqldbTableSinkOperator(String tableName, String[] columnNames) {
+        super(tableName, columnNames);
+    }
+
+    @Override
+    public HsqldbPlatform getPlatform() {
+        return HsqldbPlatform.getInstance();
+    }
+
+    @Override
+    public String createSqlClause(Connection connection, FunctionCompiler compiler) {
+        String mode = this.getMode();
+        if ("overwrite".equals(mode)) {
+            return "CREATE TABLE " + this.getTableName() + " AS (";
+        }
+        return "INSERT INTO " + this.getTableName();
+    }
+
+    @Override
+    public String createSqlSuffix() {
+        if ("overwrite".equals(this.getMode())) {
+            return ") WITH DATA"; // HSQLDB requires this suffix for CREATE TABLE AS SELECT
+        }
+        return "";
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedInputChannels(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ChannelDescriptor> getSupportedOutputChannels(int index) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/Mappings.java
+++ b/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/Mappings.java
@@ -31,7 +31,8 @@ public class Mappings {
     public static final Collection<Mapping> ALL = Arrays.asList(
             new FilterMapping(),
             new JoinMapping(),
-            new ProjectionMapping()
+            new ProjectionMapping(),
+            new TableSinkMapping()
     );
 
 }

--- a/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/TableSinkMapping.java
+++ b/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/mapping/TableSinkMapping.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.postgres.mapping;
+
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.core.mapping.Mapping;
+import org.apache.wayang.core.mapping.OperatorPattern;
+import org.apache.wayang.core.mapping.PlanTransformation;
+import org.apache.wayang.core.mapping.ReplacementSubplanFactory;
+import org.apache.wayang.core.mapping.SubplanPattern;
+import org.apache.wayang.postgres.operators.PostgresTableSinkOperator;
+import org.apache.wayang.postgres.platform.PostgresPlatform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link TableSink} to {@link PostgresTableSinkOperator}.
+ */
+public class TableSinkMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                PostgresPlatform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern<TableSink> operatorPattern = new OperatorPattern<>(
+                "sink", new TableSink<>(null, null, null), false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<TableSink>(
+                (matchedOperator, epoch) -> new PostgresTableSinkOperator(matchedOperator).at(epoch)
+        );
+    }
+}

--- a/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/operators/PostgresTableSinkOperator.java
+++ b/wayang-platforms/wayang-postgres/src/main/java/org/apache/wayang/postgres/operators/PostgresTableSinkOperator.java
@@ -16,22 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.wayang.sqlite3.mapping;
+package org.apache.wayang.postgres.operators;
 
-import org.apache.wayang.core.mapping.Mapping;
-
-import java.util.Arrays;
-import java.util.Collection;
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
 
 /**
- * Register for the {@link Mapping}s supported for this platform.
+ * PostgreSQL implementation of the {@link JdbcTableSinkOperator}.
  */
-public class Mappings {
+public class PostgresTableSinkOperator extends JdbcTableSinkOperator implements PostgresExecutionOperator {
 
-    public static final Collection<Mapping> ALL = Arrays.asList(
-            new FilterMapping(),
-            new ProjectionMapping(),
-            new TableSinkMapping()
-    );
+    public PostgresTableSinkOperator(String tableName, String[] columnNames) {
+        super(tableName, columnNames);
+    }
 
+    public PostgresTableSinkOperator(TableSink<Record> that) {
+        super(that);
+    }
 }

--- a/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/mapping/TableSinkMapping.java
+++ b/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/mapping/TableSinkMapping.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.wayang.sqlite3.mapping;
+
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.core.mapping.Mapping;
+import org.apache.wayang.core.mapping.OperatorPattern;
+import org.apache.wayang.core.mapping.PlanTransformation;
+import org.apache.wayang.core.mapping.ReplacementSubplanFactory;
+import org.apache.wayang.core.mapping.SubplanPattern;
+import org.apache.wayang.sqlite3.operators.Sqlite3TableSinkOperator;
+import org.apache.wayang.sqlite3.platform.Sqlite3Platform;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Mapping from {@link TableSink} to {@link Sqlite3TableSinkOperator}.
+ */
+public class TableSinkMapping implements Mapping {
+
+    @Override
+    public Collection<PlanTransformation> getTransformations() {
+        return Collections.singleton(new PlanTransformation(
+                this.createSubplanPattern(),
+                this.createReplacementSubplanFactory(),
+                Sqlite3Platform.getInstance()
+        ));
+    }
+
+    private SubplanPattern createSubplanPattern() {
+        final OperatorPattern<TableSink> operatorPattern = new OperatorPattern<>(
+                "sink", new TableSink<>(null, null, null), false
+        );
+        return SubplanPattern.createSingleton(operatorPattern);
+    }
+
+    private ReplacementSubplanFactory createReplacementSubplanFactory() {
+        return new ReplacementSubplanFactory.OfSingleOperators<TableSink>(
+                (matchedOperator, epoch) -> new Sqlite3TableSinkOperator(matchedOperator).at(epoch)
+        );
+    }
+}

--- a/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/operators/Sqlite3TableSinkOperator.java
+++ b/wayang-platforms/wayang-sqlite3/src/main/java/org/apache/wayang/sqlite3/operators/Sqlite3TableSinkOperator.java
@@ -16,22 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.wayang.sqlite3.mapping;
+package org.apache.wayang.sqlite3.operators;
 
-import org.apache.wayang.core.mapping.Mapping;
-
-import java.util.Arrays;
-import java.util.Collection;
+import org.apache.wayang.basic.operators.TableSink;
+import org.apache.wayang.basic.data.Record;
+import org.apache.wayang.jdbc.operators.JdbcTableSinkOperator;
+import org.apache.wayang.sqlite3.platform.Sqlite3Platform;
 
 /**
- * Register for the {@link Mapping}s supported for this platform.
+ * SQLite3 implementation of the {@link JdbcTableSinkOperator}.
  */
-public class Mappings {
+public class Sqlite3TableSinkOperator extends JdbcTableSinkOperator {
 
-    public static final Collection<Mapping> ALL = Arrays.asList(
-            new FilterMapping(),
-            new ProjectionMapping(),
-            new TableSinkMapping()
-    );
+    public Sqlite3TableSinkOperator(String tableName, String[] columnNames) {
+        super(tableName, columnNames);
+    }
 
+    public Sqlite3TableSinkOperator(TableSink<Record> that) {
+        super(that);
+    }
+
+    @Override
+    public Sqlite3Platform getPlatform() {
+        return Sqlite3Platform.getInstance();
+    }
 }


### PR DESCRIPTION
## Hey everyone!

In this PR, we introduce a database-level table sink operator that allows Wayang pipelines to complete their entire execution inside the database, without materializing intermediate data in Java or Spark. It builds on the existing `SqlQueryChannel` infrastructure and fills a gap in the JDBC operator ecosystem: while `JdbcFilterOperator`, `JdbcJoinOperator`, and `JdbcProjectionOperator` already allow composing SQL queries inside the database, there was no sink operator capable of keeping the results there too. As a result, every in-database pipeline was forced to cross the `SqlToStreamOperator` boundary and materialize data in Java/Spark memory before writing it back via JDBC `INSERT`.

The new operator wraps the composed SQL query in `CREATE TABLE x AS SELECT ...` (overwrite mode) or `INSERT INTO x SELECT ...` (append mode), executing the entire pipeline as a single SQL statement on the database connection. For pipelines where all operations can be expressed in SQL, this operator can eliminate unnecessary data movement and serialization overhead.

### What this PR adds

**Abstract operator** (`wayang-jdbc-template`)
- `JdbcTableSinkOperator` — extends the logical `TableSink<Record>` and implements `JdbcExecutionOperator`. Contributes `CREATE TABLE x AS` (overwrite) or `INSERT INTO x` (append) to the composed SQL. Accepts `SqlQueryChannel` input from its platform, declares no output channel (terminal operator).
- `createSqlSuffix()` — an extension point for dialect-specific syntax that returns an empty string by default. Production databases (PostgreSQL, SQLite, MySQL) work with the default. Subclasses can override when a specific database requires additional syntax (this is the case for HSQLDB, which we are using for the unit tests).

**Concrete platform operators** (thin wrappers, one per existing JDBC platform)
- `PostgresTableSinkOperator` (`wayang-postgres`) — implements `PostgresExecutionOperator`
- `Sqlite3TableSinkOperator` (`wayang-sqlite3`) — overrides `getPlatform()` to return `Sqlite3Platform`
- `GenericJdbcTableSinkOperator` (`wayang-generic-jdbc`) — implements `GenericJdbcExecutionOperator`

Each follows the exact pattern of the existing filter/join/projection operators on that platform.

**Mappings** (one per platform)
- `TableSinkMapping` in `wayang-postgres`, `wayang-sqlite3`, and `wayang-generic-jdbc` — transforms the logical `TableSink` into the corresponding platform-specific execution operator. Registered in each platform's `Mappings.java`.

**Executor modification** (`wayang-jdbc-template/execution/JdbcExecutor.java`)
- New `executeSinkStage()` method — detects when the terminal task of a stage is a `JdbcTableSinkOperator`, composes the SQL from the stage's operators using the existing `createSqlString()` method, and executes it directly on the database connection instead of storing it in a channel for downstream consumption. Handles overwrite mode by running `DROP TABLE IF EXISTS` as a separate statement before the main query to avoid multi-statement JDBC issues.
- The existing non-sink path is left unchanged, the new logic only activates when a sink operator is present.

**Unit tests** (`JdbcTableSinkExecutorTest.java`)
- `testOverwriteModeCreatesNewTable` — end-to-end execution against HSQLDB: creates a source table with three rows, runs the operator in overwrite mode, queries the target table back to verify data.
- `testOverwriteModeReplacesExistingTable` — verifies the drop-then-create flow by starting with a pre-existing target table of a different schema.
- `testAppendModeInsertsIntoExistingTable` — verifies that append mode preserves existing data and adds new rows.
- `testOverwriteClauseGeneration`, `testAppendClauseGeneration` — unit tests for `createSqlClause()` output in both modes.
- `HsqldbTableSinkOperator` — test-only sibling that overrides `createSqlClause`/`createSqlSuffix` for HSQLDB's parenthesized `CREATE TABLE x AS (SELECT ...) WITH DATA` syntax. This demonstrates the dialect-override extension point and keeps production SQL generation clean.

### Example usage

```java
PostgresTableSource source = new PostgresTableSource("statustype", "st_id", "st_name");

FilterOperator<Record> filter = new FilterOperator<>(
    new PredicateDescriptor<>(record -> record.getField(1).toString().equals("Completed"), Record.class)
        .withSqlImplementation("st_name = 'Completed'"),
    DataSetType.createDefault(Record.class)
);

TableSink<Record> sink = new TableSink<>(null, "overwrite", "completed_only", "st_id", "st_name");

source.connectTo(0, filter, 0);
filter.connectTo(0, sink, 0);

wayangContext.execute("In-database sink", new WayangPlan(sink));
```

With the Postgres plugin registered, the optimizer selects `PostgresTableSource`, `PostgresFilterOperator`, and `PostgresTableSinkOperator`. The composed SQL executed against the database is:

```sql
CREATE TABLE completed_only AS SELECT * FROM statustype WHERE st_name = 'Completed'
```

The entire pipeline is a single SQL statement. No data crosses the JVM boundary. Verified end-to-end against a PostgreSQL 16 instance.

### Known limitation (join output type)

During the development, we came across a pre-existing architectural challenge between Wayang's logical type system and SQL semantics. `JoinOperator` declares its output type as `Tuple2<Record, Record>`, which is correct for Java/Spark join semantics but mismatched with SQL's flat-row output. Because type checking occurs at `Operator.connectTo()` during plan construction — before the optimizer selects execution platforms — any operator chained after a join must accept `Tuple2`, forcing a manual `MapOperator` to flatten.

For Java/Spark pipelines, this is inconvenient but works. For the new in-database sink, the required flatten uses a Java lambda, which forces a `SqlToStreamOperator` boundary and breaks the in-database chain. This was previously invisible because every in-database pipeline terminated at `SqlToStreamOperator` anyway, which converts flat SQL rows into `Stream<Record>` — effectively discarding the `Tuple2` abstraction at runtime.

This PR does not resolve this. Pipelines of the form `Source → Filter → Projection → Sink` work fully in-database, but pipelines including joins still require a Java boundary after the join. A separate discussion about introducing a no-op `JdbcFlattenOperator` (or an equivalent mechanism) has been raised on the dev list. This PR intentionally stays scoped to the sink operator.

### Future work

- **Fluent API.** Neither the existing `JavaTableSink`/`SparkTableSink` nor the new JDBC sink has a `writeTable()` method in `DataQuanta.scala` / `DataQuantaBuilder.scala`. Adding it would benefit all three implementations and is a small, self-contained change. Planning a follow-up PR for this once this one lands.
- **Join → sink in-database.** As noted above, contingent on the broader discussion about the `Tuple2` vs `Record` type mismatch.

### Testing summary

- Five unit tests covering overwrite, append, and clause generation, all passing against HSQLDB.
- End-to-end verified against a real PostgreSQL 16 instance with source → sink and source → filter → sink pipelines.
- Non-sink JDBC stages are unaffected: the existing `JdbcExecutorTest` suite passes unchanged.

Thank you!