### PR TITLE
Fix compilation error in JdbcExecutor.executeSinkStage

### DIFF
--- a/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
+++ b/wayang-platforms/wayang-jdbc-template/src/main/java/org/apache/wayang/jdbc/execution/JdbcExecutor.java
@@ -129,9 +129,9 @@ public class JdbcExecutor extends ExecutorTemplate {
         // Extract operators from the stage
         final JdbcTableSource tableOp = (JdbcTableSource) startTask.getOperator();
         final JdbcTableSinkOperator sinkOp = (JdbcTableSinkOperator) termTask.getOperator();
-        final Collection<JdbcFilterOperator> filterTasks = new ArrayList<>(4);
+        final Collection<JdbcExecutionOperator> filterTasks = new ArrayList<>(4);
         JdbcProjectionOperator projectionTask = null;
-        final Collection<JdbcJoinOperator<?>> joinTasks = new ArrayList<>();
+        final Collection<JdbcExecutionOperator> joinTasks = new ArrayList<>();
 
         // Walk through intermediate operators, stopping at the sink
         ExecutionTask nextTask = JdbcExecutor.findJdbcExecutionOperatorTaskInStage(startTask, stage);


### PR DESCRIPTION
The executeSinkStage method from the PR #750 declared filterTasks and joinTasks as Collection<JdbcFilterOperator> and Collection<JdbcJoinOperator<?>> respectively, but passed them to createSqlString() which expects Collection<JdbcExecutionOperator>. Java generics are invariant so this caused a compilation failure. Fixed by makingg both local variable declarations to Collection<JdbcExecutionOperator>, matching the existing pattern in the adjacent executeQueryStage method.