### PR TITLE
Add Short and BigDecimal type mappings to SqlTypeUtils

### DIFF
--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
@@ -19,6 +19,7 @@
 package org.apache.wayang.basic.util;
 
 import org.apache.wayang.basic.data.Record;
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -42,10 +43,13 @@ public class SqlTypeUtils {
         defaultMap.put(int.class, "INT");
         defaultMap.put(Long.class, "BIGINT");
         defaultMap.put(long.class, "BIGINT");
+        defaultMap.put(Short.class, "SMALLINT");
+        defaultMap.put(short.class, "SMALLINT");
         defaultMap.put(Double.class, "DOUBLE");
         defaultMap.put(double.class, "DOUBLE");
         defaultMap.put(Float.class, "FLOAT");
         defaultMap.put(float.class, "FLOAT");
+        defaultMap.put(BigDecimal.class, "NUMERIC");
         defaultMap.put(Boolean.class, "BOOLEAN");
         defaultMap.put(boolean.class, "BOOLEAN");
         defaultMap.put(String.class, "VARCHAR(255)");

--- a/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
+++ b/wayang-commons/wayang-basic/src/main/java/org/apache/wayang/basic/util/SqlTypeUtils.java
@@ -49,7 +49,9 @@ public class SqlTypeUtils {
         defaultMap.put(double.class, "DOUBLE");
         defaultMap.put(Float.class, "FLOAT");
         defaultMap.put(float.class, "FLOAT");
-        defaultMap.put(BigDecimal.class, "NUMERIC");
+        // Explicit precision/scale (matches Spark's DecimalType default); a bare
+        // NUMERIC defaults to scale 0 on most engines and would truncate decimals.
+        defaultMap.put(BigDecimal.class, "NUMERIC(38,18)");
         defaultMap.put(Boolean.class, "BOOLEAN");
         defaultMap.put(boolean.class, "BOOLEAN");
         defaultMap.put(String.class, "VARCHAR(255)");

--- a/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/util/SqlTypeUtilsTest.java
+++ b/wayang-commons/wayang-basic/src/test/java/org/apache/wayang/basic/util/SqlTypeUtilsTest.java
@@ -51,10 +51,21 @@ public class SqlTypeUtilsTest {
         assertEquals("INT", SqlTypeUtils.getSqlType(Integer.class, DatabaseProduct.UNKNOWN));
         assertEquals("INT", SqlTypeUtils.getSqlType(int.class, DatabaseProduct.UNKNOWN));
         assertEquals("BIGINT", SqlTypeUtils.getSqlType(Long.class, DatabaseProduct.UNKNOWN));
+        assertEquals("BIGINT", SqlTypeUtils.getSqlType(long.class, DatabaseProduct.UNKNOWN));
+        assertEquals("SMALLINT", SqlTypeUtils.getSqlType(Short.class, DatabaseProduct.UNKNOWN));
+        assertEquals("SMALLINT", SqlTypeUtils.getSqlType(short.class, DatabaseProduct.UNKNOWN));
         assertEquals("DOUBLE", SqlTypeUtils.getSqlType(Double.class, DatabaseProduct.UNKNOWN));
+        assertEquals("DOUBLE", SqlTypeUtils.getSqlType(double.class, DatabaseProduct.UNKNOWN));
+        assertEquals("FLOAT", SqlTypeUtils.getSqlType(Float.class, DatabaseProduct.UNKNOWN));
+        assertEquals("FLOAT", SqlTypeUtils.getSqlType(float.class, DatabaseProduct.UNKNOWN));
+        assertEquals("NUMERIC(38,18)", SqlTypeUtils.getSqlType(java.math.BigDecimal.class, DatabaseProduct.UNKNOWN));
+        assertEquals("BOOLEAN", SqlTypeUtils.getSqlType(Boolean.class, DatabaseProduct.UNKNOWN));
+        assertEquals("BOOLEAN", SqlTypeUtils.getSqlType(boolean.class, DatabaseProduct.UNKNOWN));
         assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, DatabaseProduct.UNKNOWN));
         assertEquals("DATE", SqlTypeUtils.getSqlType(java.sql.Date.class, DatabaseProduct.UNKNOWN));
+        assertEquals("DATE", SqlTypeUtils.getSqlType(java.time.LocalDate.class, DatabaseProduct.UNKNOWN));
         assertEquals("TIMESTAMP", SqlTypeUtils.getSqlType(java.sql.Timestamp.class, DatabaseProduct.UNKNOWN));
+        assertEquals("TIMESTAMP", SqlTypeUtils.getSqlType(java.time.LocalDateTime.class, DatabaseProduct.UNKNOWN));
     }
 
     @Test
@@ -63,6 +74,10 @@ public class SqlTypeUtilsTest {
         assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(Double.class, DatabaseProduct.POSTGRESQL));
         assertEquals("DOUBLE PRECISION", SqlTypeUtils.getSqlType(double.class, DatabaseProduct.POSTGRESQL));
         assertEquals("VARCHAR(255)", SqlTypeUtils.getSqlType(String.class, DatabaseProduct.POSTGRESQL));
+        // Short and BigDecimal are not overridden for PostgreSQL, they inherit from the default map.
+        assertEquals("SMALLINT", SqlTypeUtils.getSqlType(Short.class, DatabaseProduct.POSTGRESQL));
+        assertEquals("SMALLINT", SqlTypeUtils.getSqlType(short.class, DatabaseProduct.POSTGRESQL));
+        assertEquals("NUMERIC(38,18)", SqlTypeUtils.getSqlType(java.math.BigDecimal.class, DatabaseProduct.POSTGRESQL));
     }
 
     @Test

--- a/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/operators/JavaTableSink.java
+++ b/wayang-platforms/wayang-java/src/main/java/org/apache/wayang/java/operators/JavaTableSink.java
@@ -59,6 +59,10 @@ public class JavaTableSink<T> extends TableSink<T> implements JavaExecutionOpera
             ps.setDouble(index, (Double) value);
         } else if (value instanceof Float) {
             ps.setFloat(index, (Float) value);
+        } else if (value instanceof Short) {
+            ps.setShort(index, (Short) value);
+        } else if (value instanceof java.math.BigDecimal) {
+            ps.setBigDecimal(index, (java.math.BigDecimal) value);
         } else if (value instanceof Boolean) {
             ps.setBoolean(index, (Boolean) value);
         } else if (value instanceof java.sql.Date) {

--- a/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTableSinkTest.java
+++ b/wayang-platforms/wayang-java/src/test/java/org/apache/wayang/java/operators/JavaTableSinkTest.java
@@ -32,10 +32,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -302,6 +305,60 @@ class JavaTableSinkTest extends JavaExecutionOperatorTestBase {
             assertTrue(rs.getBoolean("is_active"));
             assertEquals(5000.50, rs.getDouble("salary"), 0.001);
             assertEquals(95.5f, rs.getFloat("score"), 0.001f);
+        }
+    }
+
+    @Test
+    void testWritingAllSupportedTypesToDatabase() throws Exception {
+        Configuration configuration = new Configuration();
+        Properties dbProps = new Properties();
+        dbProps.setProperty("url", JDBC_URL);
+        dbProps.setProperty("user", "sa");
+        dbProps.setProperty("password", "");
+        dbProps.setProperty("driver", DRIVER);
+
+        JavaTableSink<Record> sink = new JavaTableSink<>(dbProps, "overwrite", TABLE_NAME,
+                new String[] { "int_col", "long_col", "short_col", "double_col", "float_col",
+                        "decimal_col", "bool_col", "string_col" },
+                DataSetType.createDefault(Record.class));
+
+        Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        final JavaExecutor javaExecutor = (JavaExecutor) JavaPlatform.getInstance().createExecutor(job);
+
+        StreamChannel.Instance input = (StreamChannel.Instance) StreamChannel.DESCRIPTOR
+                .createChannel(mock(OutputSlot.class), configuration)
+                .createInstance(javaExecutor, mock(OptimizationContext.OperatorContext.class), 0);
+
+        BigDecimal decimalValue = new BigDecimal("12.345");
+        input.accept(Stream.of(new Record(
+                42, 9_000_000_000L, (short) 7, 3.14d, 1.5f, decimalValue, true, "hello")));
+        evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
+
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\"")) {
+            rs.next();
+
+            // values written through the Java sink are read back from the database unchanged
+            assertEquals(42, rs.getInt("int_col"));
+            assertEquals(9_000_000_000L, rs.getLong("long_col"));
+            assertEquals((short) 7, rs.getShort("short_col"));
+            assertEquals(3.14d, rs.getDouble("double_col"), 1e-9);
+            assertEquals(1.5f, rs.getFloat("float_col"), 1e-6f);
+            assertEquals(0, decimalValue.compareTo(rs.getBigDecimal("decimal_col")));
+            assertTrue(rs.getBoolean("bool_col"));
+            assertEquals("hello", rs.getString("string_col"));
+
+            // the two new types were created with the right SQL column types
+            ResultSetMetaData md = rs.getMetaData();
+
+            int shortIdx = rs.findColumn("short_col");
+            assertEquals(Types.SMALLINT, md.getColumnType(shortIdx), "Short -> SMALLINT");
+
+            int decimalIdx = rs.findColumn("decimal_col");
+            assertEquals(Types.NUMERIC, md.getColumnType(decimalIdx), "BigDecimal -> NUMERIC");
+            assertEquals(38, md.getPrecision(decimalIdx), "BigDecimal precision must be 38");
+            assertEquals(18, md.getScale(decimalIdx), "BigDecimal scale must be 18");
         }
     }
 

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
@@ -141,7 +141,9 @@ public class SparkTableSink<T> extends TableSink<T> implements SparkExecutionOpe
         return ExecutionOperator.modelEagerExecution(inputs, outputs, operatorContext);
     }
 
-    private org.apache.spark.sql.types.DataType getSparkDataType(Class<?> cls) {
+    // Package-private (not private) so SparkTableSinkTest can unit-test this
+    // Java-class -> Spark DataType mapping directly; it uses no instance state.
+    org.apache.spark.sql.types.DataType getSparkDataType(Class<?> cls) {
         if (cls == Integer.class || cls == int.class)
             return DataTypes.IntegerType;
         if (cls == Long.class || cls == long.class)

--- a/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
+++ b/wayang-platforms/wayang-spark/src/main/java/org/apache/wayang/spark/operators/SparkTableSink.java
@@ -146,10 +146,14 @@ public class SparkTableSink<T> extends TableSink<T> implements SparkExecutionOpe
             return DataTypes.IntegerType;
         if (cls == Long.class || cls == long.class)
             return DataTypes.LongType;
+        if (cls == Short.class || cls == short.class)
+            return DataTypes.ShortType;
         if (cls == Double.class || cls == double.class)
             return DataTypes.DoubleType;
         if (cls == Float.class || cls == float.class)
             return DataTypes.FloatType;
+        if (cls == java.math.BigDecimal.class)
+            return DataTypes.createDecimalType(38, 18);
         if (cls == Boolean.class || cls == boolean.class)
             return DataTypes.BooleanType;
         if (cls == java.sql.Date.class || cls == java.time.LocalDate.class)

--- a/wayang-platforms/wayang-spark/src/test/java/org/apache/wayang/spark/operators/SparkTableSinkTest.java
+++ b/wayang-platforms/wayang-spark/src/test/java/org/apache/wayang/spark/operators/SparkTableSinkTest.java
@@ -21,14 +21,20 @@ import org.apache.wayang.basic.data.Record;
 import org.apache.wayang.core.platform.ChannelInstance;
 import org.apache.wayang.core.types.DataSetType;
 import org.apache.wayang.spark.channels.RddChannel;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DecimalType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -237,6 +243,109 @@ class SparkTableSinkTest extends SparkOperatorTestBase {
             assertEquals(5000.50, rs.getDouble("salary"), 0.001);
             assertEquals(95.5f, rs.getFloat("score"), 0.001f);
         }
+    }
+
+    @Test
+    void testWritingAllSupportedTypesToDatabase() throws Exception {
+        Properties dbProps = new Properties();
+        dbProps.setProperty("url", JDBC_URL);
+        dbProps.setProperty("user", "sa");
+        dbProps.setProperty("password", "");
+        dbProps.setProperty("driver", DRIVER);
+
+        String[] columns = { "int_col", "long_col", "short_col", "double_col", "float_col",
+                "decimal_col", "bool_col", "string_col" };
+
+        SparkTableSink<Record> sink = new SparkTableSink<>(dbProps, "overwrite", TABLE_NAME, columns,
+                DataSetType.createDefault(Record.class));
+
+        BigDecimal decimalValue = new BigDecimal("12.345");
+
+        Record record = new Record(
+                42,                 // int_col
+                9_000_000_000L,     // long_col
+                (short) 7,          // short_col
+                3.14d,              // double_col
+                1.5f,               // float_col
+                decimalValue,       // decimal_col
+                true,               // bool_col
+                "hello");           // string_col
+
+        RddChannel.Instance input = this.createRddChannelInstance(Arrays.asList(record));
+        evaluate(sink, new ChannelInstance[] { input }, new ChannelInstance[0]);
+
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery("SELECT * FROM \"" + TABLE_NAME + "\"")) {
+            rs.next();
+
+            // values written through Spark are read back from the database unchanged
+            assertEquals(42, rs.getInt("int_col"));
+            assertEquals(9_000_000_000L, rs.getLong("long_col"));
+            assertEquals((short) 7, rs.getShort("short_col"));
+            assertEquals(3.14d, rs.getDouble("double_col"), 1e-9);
+            assertEquals(1.5f, rs.getFloat("float_col"), 1e-6f);
+            assertEquals(0, decimalValue.compareTo(rs.getBigDecimal("decimal_col")));
+            assertTrue(rs.getBoolean("bool_col"));
+            assertEquals("hello", rs.getString("string_col"));
+
+            // the two new types were created with the right SQL column types in H2
+            ResultSetMetaData md = rs.getMetaData();
+
+            int shortIdx = rs.findColumn("short_col");
+            assertEquals(Types.SMALLINT, md.getColumnType(shortIdx), "Short -> SMALLINT");
+
+            int decimalIdx = rs.findColumn("decimal_col");
+            assertEquals(Types.NUMERIC, md.getColumnType(decimalIdx), "BigDecimal -> NUMERIC");
+            assertEquals(38, md.getPrecision(decimalIdx), "BigDecimal precision must be 38");
+            assertEquals(18, md.getScale(decimalIdx), "BigDecimal scale must be 18");
+        }
+    }
+
+    // Type-mapping checks (no database).
+    // Unlike the database tests above, these tests call getSparkDataType(...) directly to pin the Java-class -> Spark DataType
+    // contract used to build the write schema. 
+
+    // Throwaway sink instance, getSparkDataType uses no instance state.
+    private SparkTableSink<Record> mappingProbe() {
+        return new SparkTableSink<>(new Properties(), "overwrite", "probe",
+                new String[] { "c" }, DataSetType.createDefault(Record.class));
+    }
+
+    @Test
+    void getSparkDataType_mapsBigDecimalToDecimal38_18() {
+        DataType type = mappingProbe().getSparkDataType(BigDecimal.class);
+        assertTrue(type instanceof DecimalType, "BigDecimal must map to a DecimalType");
+        DecimalType decimal = (DecimalType) type;
+        assertEquals(38, decimal.precision(), "BigDecimal precision must be 38");
+        assertEquals(18, decimal.scale(), "BigDecimal scale must be 18");
+    }
+
+    @Test
+    void getSparkDataType_mapsAllSupportedTypes() {
+        SparkTableSink<Record> s = mappingProbe();
+        assertEquals(DataTypes.IntegerType, s.getSparkDataType(Integer.class));
+        assertEquals(DataTypes.IntegerType, s.getSparkDataType(int.class));
+        assertEquals(DataTypes.LongType, s.getSparkDataType(Long.class));
+        assertEquals(DataTypes.LongType, s.getSparkDataType(long.class));
+        assertEquals(DataTypes.ShortType, s.getSparkDataType(Short.class));
+        assertEquals(DataTypes.ShortType, s.getSparkDataType(short.class));
+        assertEquals(DataTypes.DoubleType, s.getSparkDataType(Double.class));
+        assertEquals(DataTypes.DoubleType, s.getSparkDataType(double.class));
+        assertEquals(DataTypes.FloatType, s.getSparkDataType(Float.class));
+        assertEquals(DataTypes.FloatType, s.getSparkDataType(float.class));
+        assertEquals(DataTypes.BooleanType, s.getSparkDataType(Boolean.class));
+        assertEquals(DataTypes.BooleanType, s.getSparkDataType(boolean.class));
+        assertEquals(DataTypes.DateType, s.getSparkDataType(java.sql.Date.class));
+        assertEquals(DataTypes.DateType, s.getSparkDataType(java.time.LocalDate.class));
+        assertEquals(DataTypes.TimestampType, s.getSparkDataType(java.sql.Timestamp.class));
+        assertEquals(DataTypes.TimestampType, s.getSparkDataType(java.time.LocalDateTime.class));
+    }
+
+    @Test
+    void getSparkDataType_fallsBackToStringForUnsupportedTypes() {
+        SparkTableSink<Record> s = mappingProbe();
+        assertEquals(DataTypes.StringType, s.getSparkDataType(Object.class));
+        assertEquals(DataTypes.StringType, s.getSparkDataType(java.util.UUID.class));
     }
 
     public static class TestPojo implements java.io.Serializable {


### PR DESCRIPTION
## Summary
Adds proper SQL type support for `Short` and `java.math.BigDecimal` across the
table-sink write path. Previously neither had a JDBC type mapping, so the sink
created such columns as `VARCHAR(255)` (numbers stored as text, with no numeric
ordering/aggregation in the DB). This PR maps them to real numeric SQL types and
binds their values correctly on both the Java and Spark execution paths.

## Changes

**1. Type mapping (`SqlTypeUtils`)**
- `Short` / `short` → `SMALLINT`
- `BigDecimal` → `NUMERIC(38,18)`
- The PostgreSQL dialect inherits both from the default map.

**2. Value binding (the DDL type alone is not enough)**
Mapping the column type without binding the value would bind a *string* into a
numeric column. Each in-JVM sink is fixed:
- `JavaTableSink`: bind via `PreparedStatement.setShort(...)` / `setBigDecimal(...)`
  instead of the `setString` fallback.
- `SparkTableSink`: map `Short → DataTypes.ShortType` and
  `BigDecimal → DataTypes.createDecimalType(38, 18)`, so the DataFrame schema
  (and the JDBC write derived from it) produces `SMALLINT` / `NUMERIC(38,18)`.

## Why `NUMERIC(38,18)` rather than a bare `NUMERIC`
A bare `NUMERIC` is **not portable for decimals**. Per the SQL standard, omittting
the scale means scale 0, so most engines create an *integer* column and silently
truncate the fractional part: H2, MySQL (`DECIMAL(10,0)`), SQL Server
(`DECIMAL(18,0)`), Derby, DB2 all do this (e.g. `12.345 → 12`). PostgreSQL is the
lenient exception (bare `NUMERIC` is unbounded), which can hide the bug. An
explicit scale avoids the truncation on every database.

## Why specifically `38` and `18`
These are **not arbitrary**: `(38, 18)` is Spark's `DecimalType.SYSTEM_DEFAULT` —
the precision/scale Spark assigns to a decimal when none is otherwise known
(`38` is also the maximum precision Spark's `Decimal` supports, and a value widely
supported by Oracle/SQL Server). We deliberately reuse the **same** values on the
Java/DDL path (`SqlTypeUtils → NUMERIC(38,18)`):
- `38` = max total significant digits (generous headroom),
- `18` = digits after the decimal point (ample for monetary/rate data),
- and, crucially, this makes the **Java and Spark sinks emit identical column
  types** for a `BigDecimal`. In Wayang the optimizer decides which platform runs
  the sink, so the output schema must not depend on that choice — matching Spark's
  default keeps both paths consistent.

Trade-off: a fixed scale pads short values with trailing zeros
(`12.345 → 12.345000000000000000`). This is numerically identical and is exactly
what the Spark path already produced;=, in return decimals aree portable and lossless
across all databases.

## Tests
- `SqlTypeUtilsTest`: the full default type map (incl. `Short → SMALLINT`,
  `BigDecimal → NUMERIC(38,18)`) and PostgreSQL inheritance.
- `SparkTableSinkTest`:
  - direct mapping checks for `getSparkDataType(...)` — the whole Java-class →
    Spark `DataType` table, the `String` fallback, and explicitly
    `BigDecimal → DecimalType(precision=38, scale=18)`;
  - an end-to-end write of all supported types to in-memory H2, asserting the
    round-tripped values and the created column types (`SMALLINT`, `NUMERIC(38,18)`).
- `JavaTableSinkTest`: the analogous end-to-end test for the Java sink.

All tests run against in-memory H2 — no external database required.

## Notes
- The in-database JDBC sinks (`PostgresTableSinkOperator`, etc.) are unaffected :
  they compose `CREATE TABLE ... AS SELECT` and let the DB infer types, so they
  never bind a Java value or use `SqlTypeUtils`.
- `getSparkDataType` was widened from `private` to package-private only to make
  the mapping unit-testable.
