### PR TITLE
[WAYANG-768] Fix test initialization in JdbcJoinOperatorTest

### DIFF
--- a/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/JdbcJoinOperatorTest.java
+++ b/wayang-platforms/wayang-jdbc-template/src/test/java/org/apache/wayang/jdbc/operators/JdbcJoinOperatorTest.java
@@ -33,6 +33,7 @@ import org.apache.wayang.core.function.TransformationDescriptor;
 import org.apache.wayang.jdbc.execution.JdbcExecutor;
 import org.apache.wayang.core.profiling.NoInstrumentationStrategy;
 import org.apache.wayang.core.optimizer.DefaultOptimizationContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -48,6 +49,21 @@ import static org.mockito.Mockito.when;
  * Test suite for {@link SqlToStreamOperator}.
  */
 class JdbcJoinOperatorTest extends OperatorTestBase {
+    @BeforeEach
+    void initDB() throws SQLException {
+        HsqldbPlatform hsqldbPlatform = new HsqldbPlatform();
+        try (
+            Connection jdbcConnection = hsqldbPlatform
+                .createDatabaseDescriptor(configuration)
+                .createJdbcConnection()
+        ) {
+            final Statement statement = jdbcConnection.createStatement();
+            statement.execute("DROP TABLE IF EXISTS testA");
+            statement.execute("DROP TABLE IF EXISTS testB");
+            statement.execute("DROP TABLE IF EXISTS orders");
+            statement.execute("DROP TABLE IF EXISTS shipments");
+        }
+    }
     @Test
     void testWithHsqldb() throws SQLException {
         Configuration configuration = new Configuration();


### PR DESCRIPTION
# Title: [WAYANG-768] Fix test initialization in JdbcJoinOperatorTest

## Description:
This PR fixes the intermittent test failures in JdbcJoinOperatorTest caused by table name collisions.(this: https://github.com/apache/wayang/issues/768)

## Changes:

   - Updated test setup to use `@BeforeEach` for cleaner lifecycle management.

   - Added explicit `initDB` calls to ensure database schema is fresh before running tests.

## Testing:

The changes were verified by running the full test suite with Maven.
run: `./mvnw clean test`
All tests passed successfully (log output attached below).

```
[INFO] Results:
[INFO]
[WARNING] Tests run: 121, Failures: 0, Errors: 0, Skipped: 2
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache Wayang 1.1.2-SNAPSHOT:
[INFO]
[INFO] Apache Wayang ...................................... SUCCESS [ 15.729 s]
[INFO] Wayang Commons ..................................... SUCCESS [  0.023 s]
[INFO] wayang-utils-profile-db ............................ SUCCESS [  4.864 s]
[INFO] Wayang Core ........................................ SUCCESS [ 21.994 s]
[INFO] Wayang Basic ....................................... SUCCESS [01:45 min]
[INFO] Wayang Platform .................................... SUCCESS [  0.016 s]
[INFO] Wayang Platform Java ............................... SUCCESS [  8.337 s]
[INFO] Wayang Platform Spark .............................. SUCCESS [ 44.877 s]
[INFO] Wayang Platform JDBC Template ...................... SUCCESS [  4.214 s]
[INFO] Wayang Platform Postgres ........................... SUCCESS [  0.678 s]
[INFO] Wayang Platform SQLite3 ............................ SUCCESS [  0.836 s]
[INFO] Wayang Platform Giraph ............................. SUCCESS [  9.528 s]
[INFO] Wayang API ......................................... SUCCESS [  0.010 s]
[INFO] Wayang API Python .................................. SUCCESS [  0.960 s]
[INFO] Wayang Platform Tensorflow ......................... SUCCESS [ 10.860 s]
[INFO] Wayang API Utils ................................... SUCCESS [  2.892 s]
[INFO] wayang-api-sql ..................................... SUCCESS [ 11.905 s]
[INFO] Wayang Platform Apache Flink ....................... SUCCESS [ 15.836 s]
[INFO] Wayang Platform Generic Jdbc ....................... SUCCESS [  1.047 s]
[INFO] Wayang API Scala-Java .............................. SUCCESS [ 15.625 s]
[INFO] Wayang API JSON .................................... SUCCESS [ 15.221 s]
[INFO] Wayang Profiler .................................... SUCCESS [  1.099 s]
[INFO] Wayang Extensions .................................. SUCCESS [  0.014 s]
[INFO] wayang-iejoin ...................................... SUCCESS [  4.187 s]
[INFO] wayang-spatial ..................................... SUCCESS [  8.575 s]
[INFO] Wayang - Common resources .......................... SUCCESS [  0.010 s]
[INFO] wayang-benchmark ................................... SUCCESS [ 24.692 s]
[INFO] Wayang ML4all ...................................... SUCCESS [  9.498 s]
[INFO] Wayang Project Assembly ............................ SUCCESS [  0.544 s]
[INFO] wayang-applications ................................ SUCCESS [  0.798 s]
[INFO] Wayang Integration Test ............................ SUCCESS [ 23.991 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  07:16 min
[INFO] Finished at: 2026-06-10T22:45:57Z
[INFO] ------------------------------------------------------------------------
```