### PR TITLE
Fix non-deterministic crash in TensorflowModelTest  (#778)

### DIFF
--- a/wayang-platforms/wayang-tensorflow/src/test/java/org/apache/wayang/tensorflow/model/TensorflowModelTest.java
+++ b/wayang-platforms/wayang-tensorflow/src/test/java/org/apache/wayang/tensorflow/model/TensorflowModelTest.java
@@ -71,15 +71,22 @@ class TensorflowModelTest {
         try (TensorflowModel tfModel = new TensorflowModel(model, criterion, optimizer, acc)) {
             System.out.println(tfModel.getOut().getName());
             tfModel.train(x, y, 100, 6);
-            TFloat32 predicted = tfModel.predict(x);
-            Ops tf = Ops.create();
-            org.tensorflow.op.math.ArgMax<TInt32> argMax = tf.math.argMax(tf.constantOf(predicted), tf.constant(1), TInt32.class);
-            final TInt32 tensor = argMax.asTensor();
-            System.out.print("[ ");
-            for (int i = 0; i < tensor.shape().size(0); i++) {
-                System.out.print(tensor.getInt(i) + " ");
+            try (TFloat32 predicted = tfModel.predict(x)) {
+                System.out.print("[ ");
+                for (int i = 0; i < predicted.shape().size(0); i++) {
+                    float max = -Float.MAX_VALUE;
+                    int maxIdx = -1;
+                    for (int j = 0; j < predicted.shape().size(1); j++) {
+                        float val = predicted.getFloat(i, j);
+                        if (val > max) {
+                            max = val;
+                            maxIdx = j;
+                        }
+                    }
+                    System.out.print(maxIdx + " ");
+                }
+                System.out.println("]");
             }
-            System.out.println("]");
         }
         System.out.println();
     }


### PR DESCRIPTION
### Description

  Fixes #778
  What was the issue?
  The  TensorflowModelTest  was non-deterministically failing during the Maven Surefire teardown phase, causing the build to    
  fail with a  SIGABRT  (Process Exit Code: 134) and the error: "The forked VM terminated without properly saying goodbye".     

  This issue was traced back to native memory resource leaks in the test file. The test utilized an unclosed  Ops.create()      
  (which spins up a global EagerSession) and unclosed Eager  Tensor  instances (such as  predicted ,  tf.constant , and
  argMax ) for printing test predictions. When the JVM began shutting down, the garbage collector would attempt to clean        
  these up concurrently, causing a race condition and a native crash within the TensorFlow C API.

  How was it fixed?

  • Wrapped the  predicted  graph tensor in a Java  try-with-resources  block to ensure deterministic and safe na-tive memory    
  cleanup.
  • Replaced the EagerSession and TensorFlow  argMax  operations with a standard Java nested loop to compute the  argmax .      

  ### How was this tested?

  [✓] Reproduced the original crash locally using  mvn test -Dtest=TensorflowModelTest -pl wayang-platforms/wayang-tensorflow . 
  [✓] Verified that the test now reliably passes and prints the expected predictions without throwing a VM crash during JVM     
  teardown.

@zkaoudi 